### PR TITLE
Replace lodash with lodash-es for tree-shakeable ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,15 @@
   "dependencies": {
     "@3d-dice/dice-box": "^0.4.19",
     "@mdi/font": "^6.5.95",
-    "lodash": "^4.17.21",
+    "@types/deep-freeze": "^0.1.2",
+    "deep-freeze": "^0.0.1",
+    "lodash-es": "^4.17.21",
     "vue": "^3.2.0",
     "vuetify": "^3.1.1",
     "vuex": "^4.0.2",
     "webfontloader": "^1.0.0"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.178",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",
     "@vitejs/plugin-vue": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
   "dependencies": {
     "@3d-dice/dice-box": "^0.4.19",
     "@mdi/font": "^6.5.95",
-    "@types/deep-freeze": "^0.1.2",
-    "deep-freeze": "^0.0.1",
     "lodash-es": "^4.17.21",
     "vue": "^3.2.0",
     "vuetify": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ dependencies:
   '@mdi/font':
     specifier: ^6.5.95
     version: 6.9.96
-  lodash:
+  lodash-es:
     specifier: ^4.17.21
     version: 4.18.1
   vue:
@@ -28,9 +28,6 @@ dependencies:
     version: 1.6.28
 
 devDependencies:
-  '@types/lodash':
-    specifier: ^4.14.178
-    version: 4.17.24
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.10.0
     version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@4.4.4)
@@ -411,10 +408,6 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-    dev: true
-
-  /@types/lodash@4.17.24:
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
     dev: true
 
   /@types/node@26.1.1:
@@ -2902,6 +2895,10 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+    dev: false
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
@@ -2912,6 +2909,7 @@ packages:
 
   /lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+    dev: true
 
   /magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}

--- a/src/components/game/Marker.vue
+++ b/src/components/game/Marker.vue
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue"
-import _ from "lodash"
+import { padStart } from "lodash-es"
 import { PlayerId } from "~/models/player"
 
 export default defineComponent({
@@ -40,7 +40,7 @@ export default defineComponent({
   },
   computed: {
     imageUrl() {
-      const id = _.padStart(String(this.color * 12 + this.marker + 1), 2, "0")
+      const id = padStart(String(this.color * 12 + this.marker + 1), 2, "0")
       return new URL(`../../assets/markers/marker-${id}.svg`, import.meta.url).href
     },
     fullTransform() {

--- a/src/components/game/battle/RangestrikeConfirmation.vue
+++ b/src/components/game/battle/RangestrikeConfirmation.vue
@@ -29,7 +29,7 @@
 </template>
 <script lang="ts">
 import { defineComponent, PropType } from "vue"
-import _ from "lodash"
+import { isEqual } from "lodash-es"
 import { mapGetters, mapState } from "vuex"
 import { BattleCreature, RangestrikeTarget, Strike } from "~/models/battle"
 import { div } from "~/utils/math"
@@ -66,7 +66,7 @@ export default defineComponent({
       }
     },
     targetedStrikeWasAdjusted(): boolean {
-      return !_.isEqual(this.targetedStrikeUnadjusted, this.targetedStrike)
+      return !isEqual(this.targetedStrikeUnadjusted, this.targetedStrike)
     }
   }
 })

--- a/src/components/game/battle/StrikeConfirmation.vue
+++ b/src/components/game/battle/StrikeConfirmation.vue
@@ -51,7 +51,7 @@
 </template>
 <script lang="ts">
 import { defineComponent, PropType } from "vue"
-import _ from "lodash"
+import { isEqual, range } from "lodash-es"
 import { mapGetters, mapState } from "vuex"
 import { BattleCreature, isRangestrike, Strike } from "~/models/battle"
 
@@ -86,12 +86,12 @@ export default defineComponent({
         isRangestrike(this.targetedCreature) ? this.targetedCreature.creature : this.targetedCreature)
     },
     targetedStrikeWasAdjusted(): boolean {
-      return !_.isEqual(this.targetedStrikeUnadjusted, this.targetedStrike)
+      return !isEqual(this.targetedStrikeUnadjusted, this.targetedStrike)
     },
     toHitAdjustments(): Record<number, BattleCreature[]> {
       return this.tougherCarryovers.reduce((adjustments: Record<number, BattleCreature[]>, creature) => {
         const toHit = this.activeBattle.toHitAdjusted(this.selectedCreature, creature)
-        _.range(toHit, 7).forEach(numToUpdate =>
+        range(toHit, 7).forEach(numToUpdate =>
           adjustments[numToUpdate] = [...(adjustments[numToUpdate] ?? []), creature])
         return adjustments
       }, {})

--- a/src/components/game/masterboard/Masterboard.vue
+++ b/src/components/game/masterboard/Masterboard.vue
@@ -33,7 +33,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue"
-import _ from "lodash"
+import { range, sortBy } from "lodash-es"
 import { mapActions, mapGetters, mapMutations, mapState } from "vuex"
 import { MasterboardPhase, Path } from "~/models/game"
 import { MasterboardHex } from "~/models/masterboard"
@@ -54,12 +54,12 @@ export default defineComponent({
     ...mapState("game", ["activePhase", "stacks", "activeRoll"]),
     ...mapGetters("ui/selections", ["paths", "focusedStack", "selectedStack"]),
     sortedStacks(): Stack[] {
-      lastSortedStacks = _.sortBy(this.stacks, stack =>
+      lastSortedStacks = sortBy(this.stacks, stack =>
         stack === this.selectedStack ? 999 : lastSortedStacks.indexOf(stack))
       return lastSortedStacks
     },
     interleavedPaths(): [boolean, MasterboardHex][] {
-      return _.range(this.paths[0].path.length).map((colIndex: number) =>
+      return range(this.paths[0].path.length).map((colIndex: number) =>
         this.paths.map((row: Path) => [row.foe !== undefined, row.path[colIndex]])).slice(1)
     },
     canFreeMove(): boolean {

--- a/src/components/ui/game/MusterChoices.vue
+++ b/src/components/ui/game/MusterChoices.vue
@@ -42,7 +42,7 @@
 </template>
 <script lang="ts">
 import { defineComponent } from "vue"
-import _ from "lodash"
+import { fill } from "lodash-es"
 import { mapState } from "vuex"
 import { CREATURE_DATA } from "~/models/creature"
 import { MasterboardPhase } from "~/models/game"
@@ -97,7 +97,7 @@ export default defineComponent({
   methods: {
     choose(possibility: MusterPossibility) {
       this.chosen = possibility
-      _.fill(this.dialogState, false)
+      fill(this.dialogState, false)
     }
   }
 })

--- a/src/components/ui/game/StackPanel.vue
+++ b/src/components/ui/game/StackPanel.vue
@@ -85,7 +85,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue"
-import _ from "lodash"
+import { capitalize } from "lodash-es"
 import { mapActions, mapGetters, mapMutations, mapState } from "vuex"
 import { CREATURE_DATA, CreatureType } from "~/models/creature"
 import { MasterboardPhase } from "~/models/game"
@@ -121,7 +121,7 @@ export default defineComponent({
         : this.focusedHex?.terrain
     },
     musteringTerrainName(): string {
-      return _.capitalize(Terrain[this.musteringTerrain])
+      return capitalize(Terrain[this.musteringTerrain])
     },
     musterable(): MusterPossibility[] {
       return this.focusedStack?.musterable(this.musteringTerrain)

--- a/src/components/ui/game/TurnPanel.vue
+++ b/src/components/ui/game/TurnPanel.vue
@@ -78,7 +78,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue"
-import _ from "lodash"
+import { sum } from "lodash-es"
 import { mapActions, mapGetters, mapMutations, mapState } from "vuex"
 import { MasterboardPhase } from "~/models/game"
 import { Stack } from "~/models/stack"
@@ -109,13 +109,13 @@ export default defineComponent({
       }
     },
     sevenHighCount(): number {
-      return _.sum(this.activeStacks.map((stack: Stack) => stack.creatures.length === 7))
+      return sum(this.activeStacks.map((stack: Stack) => stack.creatures.length === 7))
     },
     movedCount(): number {
-      return _.sum(this.activeStacks.map((stack: Stack) => stack.hasMoved()))
+      return sum(this.activeStacks.map((stack: Stack) => stack.hasMoved()))
     },
     musteredCount(): number {
-      return _.sum(this.activeStacks.map((stack: Stack) => stack.currentMuster !== undefined))
+      return sum(this.activeStacks.map((stack: Stack) => stack.currentMuster !== undefined))
     },
     engagementsMessage(): string {
       if (this.engagedStacks.length < 1) {

--- a/src/components/ui/generic/DiceRoller.vue
+++ b/src/components/ui/generic/DiceRoller.vue
@@ -7,7 +7,7 @@
 <script lang="ts">
 import DiceBox from "@3d-dice/dice-box"
 import { defineComponent } from "vue"
-import _ from "lodash"
+import { random, range, set } from "lodash-es"
 import { mapState } from "vuex"
 
 interface ComponentData {
@@ -61,7 +61,7 @@ export default defineComponent({
       this.resolve = undefined
       this.rolling = false
     }
-    _.set(this, "diceBox", diceBox)
+    set(this, "diceBox", diceBox)
   },
   methods: {
     async roll(quantity?: number) {
@@ -82,7 +82,7 @@ export default defineComponent({
           this.diceBox.roll(`${quantity ?? 1}d6`)
           if (this.quickDice) {
             setTimeout(() => {
-              this.resolve?.(_.range(quantity ?? 1).map(i => _.random(1, 6)))
+              this.resolve?.(range(quantity ?? 1).map(i => random(1, 6)))
               this.reject = undefined
               this.resolve = undefined
               this.rolling = false

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import _ from "lodash"
+import { random } from "lodash-es"
 import { createApp } from "vue"
 import App from "~/App.vue"
 import vuetify from "~/plugins/vuetify"
@@ -6,7 +6,7 @@ import vuex from "~/plugins/vuex"
 import { loadFonts } from "~/plugins/webfontloader"
 
 (() => {
-  let idCounter = _.random(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+  let idCounter = random(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
   // eslint-disable-next-line no-extend-native
   Object.defineProperty(Object.prototype, "__guid", {
     writable: true

--- a/src/models/battle.ts
+++ b/src/models/battle.ts
@@ -1,4 +1,4 @@
-import _, { omit, sum } from "lodash"
+import { clamp, memoize, omit, sum } from "lodash-es"
 import { assert } from "~/utils/assert"
 import { div } from "~/utils/math"
 import { CREATURE_DATA, CreatureType } from "./creature"
@@ -73,8 +73,8 @@ export function isRangestrike(arg: BattleCreature | RangestrikeTarget): arg is R
   return "creature" in arg && "adjustment" in arg && "longDistance" in arg
 }
 
-export const combineStrikes = (a: Strike, b: Strike, clamp?: boolean): Strike => ({
-  toHit: clamp === false ? a.toHit + b.toHit : _.clamp(a.toHit + b.toHit, 2, 6),
+export const combineStrikes = (a: Strike, b: Strike, clampVal?: boolean): Strike => ({
+  toHit: clampVal === false ? a.toHit + b.toHit : clamp(a.toHit + b.toHit, 2, 6),
   dice: a.dice + b.dice
 })
 
@@ -247,7 +247,7 @@ export class Battle {
 
   // Parameters optional for Hydration
   constructor(hex: number, edge: HexEdge, game: TitanGame, attacking?: Stack, defending?: Stack) {
-    this.creatureOnHex = _.memoize(this.creatureOnHex)
+    this.creatureOnHex = memoize(this.creatureOnHex)
     this.round = 0
     this.phase = BattlePhase.DEFENDER_MOVE
     this.hex = hex

--- a/src/models/creature.ts
+++ b/src/models/creature.ts
@@ -1,4 +1,4 @@
-import _ from "lodash"
+import { capitalize } from "lodash-es"
 import { assert } from "~/utils/assert"
 import { div } from "~/utils/math"
 import { Terrain } from "./masterboard"
@@ -44,7 +44,7 @@ export class Creature {
     flying?: boolean, ranged?: boolean, lord?: boolean) {
     this.type = type
     this.initialQuantity = quantity ?? 0
-    this.name = _.capitalize(CreatureType[type])
+    this.name = capitalize(CreatureType[type])
     assert(strength >= 3 && strength <= 18, "Invalid creature strength")
     this.strength = strength
     assert(skill >= 2 && skill <= 4, "Invalid creature skill")

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -1,4 +1,4 @@
-import _ from "lodash"
+import { assign, matches, range, shuffle } from "lodash-es"
 import { BaseActionContext } from "~/store/types"
 import { View } from "~/store/ui/selection"
 import { assert } from "~/utils/assert"
@@ -86,8 +86,8 @@ export class TitanGame {
     this.activeRoll = undefined
     this.activeBattle = undefined
     this.activePhase = MasterboardPhase.SPLIT
-    const colors = _.shuffle(_.range(0, 5))
-    this.players = _.range(0, numPlayers).map(i => new Player(colors[i], `Player ${i + 1}`))
+    const colors = shuffle(range(0, 5))
+    this.players = range(0, numPlayers).map(i => new Player(colors[i], `Player ${i + 1}`))
     this.stacks = this.players.map((player: Player, i: number) =>
       new Stack(player?.id, INITIAL_HEXES[numPlayers][i], 0))
 
@@ -122,7 +122,7 @@ export class TitanGame {
 
   getNextMarker(getters: Getters): number | undefined {
     const usedMarkers = getters.activeStacks.map(stack => stack.marker)
-    return _.range(0, 12).find(marker => !usedMarkers.includes(marker))
+    return range(0, 12).find(marker => !usedMarkers.includes(marker))
   }
 
   getStacksForHex() {
@@ -325,24 +325,24 @@ export class TitanGame {
   }
 
   mMoveCreature({ creature, hex }: BattleMovePayload): void {
-    assert(this.activeBattle?.creatures.some(_.matches(creature)) ?? false, "Unexpected creature")
+    assert(this.activeBattle?.creatures.some(matches(creature)) ?? false, "Unexpected creature")
     creature.hex = hex
   }
 
   mAttackCreature({ attacker, target, rolls, optionalToHit }: AttackPayload): void {
-    assert(this.activeBattle?.creatures.some(_.matches(attacker)) ?? false, "Unexpected attacker")
-    assert(this.activeBattle?.creatures.some(_.matches(target)) ?? false, "Unexpected defender")
+    assert(this.activeBattle?.creatures.some(matches(attacker)) ?? false, "Unexpected attacker")
+    assert(this.activeBattle?.creatures.some(matches(target)) ?? false, "Unexpected defender")
     this.activeBattle?.strike(attacker, target, rolls, optionalToHit)
   }
 
   mRangestrikeCreature({ attacker, target, rolls }: RangestrikePayload): void {
-    assert(this.activeBattle?.creatures.some(_.matches(attacker)) ?? false, "Unexpected attacker")
-    assert(this.activeBattle?.creatures.some(_.matches(target.creature)) ?? false, "Unexpected defender")
+    assert(this.activeBattle?.creatures.some(matches(attacker)) ?? false, "Unexpected attacker")
+    assert(this.activeBattle?.creatures.some(matches(target.creature)) ?? false, "Unexpected defender")
     this.activeBattle?.rangestrike(attacker, target, rolls)
   }
 
   mAssignCarryover(target: BattleCreature): void {
-    assert(this.activeBattle?.creatures.some(_.matches(target)) ?? false, "Unexpected target")
+    assert(this.activeBattle?.creatures.some(matches(target)) ?? false, "Unexpected target")
     this.activeBattle?.carryover(target)
   }
 
@@ -482,12 +482,12 @@ export class TitanGame {
   }
 
   mRehydrate(hydration: TitanGame): void {
-    _.assign(this, {
+    assign(this, {
       ...hydration,
       players: hydration.players.map((player: Player) =>
-        _.assign(new Player(player.id, player.name), player)),
+        assign(new Player(player.id, player.name), player)),
       stacks: hydration.stacks.map((stack: Stack) =>
-        _.assign(new Stack(stack.owner, stack.hex, stack.marker, stack.creatures), stack)),
+        assign(new Stack(stack.owner, stack.hex, stack.marker, stack.creatures), stack)),
       activeBattle: hydration.activeBattle !== undefined ? Battle.hydrate(hydration.activeBattle, this) : undefined
     })
   }

--- a/src/models/stack.ts
+++ b/src/models/stack.ts
@@ -1,4 +1,4 @@
-import _ from "lodash"
+import { range, remove, sum } from "lodash-es"
 import { assert } from "~/utils/assert"
 import { CREATURE_DATA, CreatureType, MUSTER_DATA } from "./creature"
 import { HexEdge, Terrain } from "./masterboard"
@@ -27,7 +27,7 @@ export class Stack {
       CreatureType.CENTAUR, CreatureType.CENTAUR,
       CreatureType.OGRE, CreatureType.OGRE,
       CreatureType.GARGOYLE, CreatureType.GARGOYLE]
-    this.split = _.range(8).map(i => false)
+    this.split = range(8).map(i => false)
     this.hex = start
     this.origin = start
     this.marker = marker
@@ -35,7 +35,7 @@ export class Stack {
   }
 
   numSplitting(): number {
-    return _.sum(this.split.map(i => i ? 1 : 0))
+    return sum(this.split.map(i => i ? 1 : 0))
   }
 
   hasMoved(): boolean {
@@ -52,7 +52,7 @@ export class Stack {
       if (numSplitting !== 4) {
         return false
       }
-      const splitLords: number = _.sum(this.creatures.map((creature, index) =>
+      const splitLords: number = sum(this.creatures.map((creature, index) =>
         this.split[index] && CREATURE_DATA[creature].lord))
       if (splitLords !== 1) {
         return false
@@ -67,7 +67,7 @@ export class Stack {
   }
 
   getValue(): number {
-    return _.sum(this.creatures.map(creature => CREATURE_DATA[creature].getValue()))
+    return sum(this.creatures.map(creature => CREATURE_DATA[creature].getValue()))
   }
 
   musterable(terrain: Terrain): MusterPossibility[] {
@@ -119,7 +119,7 @@ export class Stack {
     assert(this.isValidSplit(), "Invalid split")
     assert(marker >= 0, "Invalid marker")
     const creatures = this.getCreaturesSplit(true)
-    _.remove(this.creatures, (creature, index) => this.split[index])
+    remove(this.creatures, (creature, index) => this.split[index])
     this.split.fill(false)
     return new Stack(this.owner, this.hex, marker, creatures)
   }

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,6 +1,6 @@
 // Styles
 import "@mdi/font/css/materialdesignicons.css"
-import _ from "lodash"
+import { map } from "lodash-es"
 
 // Vuetify
 import { createVuetify } from "vuetify"
@@ -21,7 +21,7 @@ const titanColors = {
   "titan-purple": "#bd0cbd"
 }
 
-const playerColors = Object.fromEntries(_.map(titanColors,
+const playerColors = Object.fromEntries(map(titanColors,
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   (color, name) => [`player-${PlayerId[name.split("-")[1].toUpperCase()]}`, color])
   .filter(entry => entry[0] !== "player-undefined"))

--- a/src/store/game/index.ts
+++ b/src/store/game/index.ts
@@ -1,9 +1,9 @@
-import _ from "lodash"
+import { lowerFirst } from "lodash-es"
 import { TitanGame } from "~/models/game"
 
 const titanGameMethods = Object.getOwnPropertyNames(TitanGame.prototype)
 
-const mapStateMethod = (prefixLen: number) => (name: string) => [_.lowerFirst(name.slice(prefixLen)),
+const mapStateMethod = (prefixLen: number) => (name: string) => [lowerFirst(name.slice(prefixLen)),
   (state: any, ...args: any[]) => state[name](...args)]
 const titanGameGetters = Object.fromEntries(titanGameMethods
   .filter(name => name.startsWith("get")).map(mapStateMethod(3)))
@@ -11,7 +11,7 @@ const titanGameGetters = Object.fromEntries(titanGameMethods
 const titanGameMutations = Object.fromEntries(titanGameMethods
   .filter(name => name.startsWith("m")).map(mapStateMethod(1)))
 
-const mapStateAction = (prefixLen: number) => (name: string) => [_.lowerFirst(name.slice(prefixLen)),
+const mapStateAction = (prefixLen: number) => (name: string) => [lowerFirst(name.slice(prefixLen)),
   (context: any, ...args: any[]) => context.state[name](context, ...args)]
 const titanGameActions = Object.fromEntries(titanGameMethods
   .filter(name => name.startsWith("do")).map(mapStateAction(2)))


### PR DESCRIPTION
Swap from the CommonJS 'lodash' package to 'lodash-es' for tree-shakeable ES modules in Vite builds. This enables proper tree-shaking to reduce bundle size.