### PR TITLE
Fix Node 24 in CI build workflow (was Node 22 in #37)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "yarn"
 
       - run: mv tsconfig.json tsconfig.unused


### PR DESCRIPTION
Restores Node version to match proposal 01's documented decision. PR #37 mistakenly downgraded from the LTS version required by Vite 8.

Build and install steps verified locally.