### PR TITLE
Upgrade TypeScript to 6.0.3 and add a typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
+    "typecheck": "vue-tsc --noEmit",
     "dev": "vite",
     "start": "node .output/server/index.mjs"
   },
@@ -22,6 +23,7 @@
     "webfontloader": "^1.0.0"
   },
   "devDependencies": {
+    "@types/lodash-es": "^4.17.12",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",
     "@vitejs/plugin-vue": "^1.2.4",
@@ -34,7 +36,8 @@
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "^8.3.0",
     "sass": "^1.38.0",
-    "typescript": "<4.5.0",
-    "vite": "^2.9.16"
+    "typescript": "6.0.3",
+    "vite": "^2.9.16",
+    "vue-tsc": "^3.3.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ dependencies:
     version: 4.18.1
   vue:
     specifier: ^3.2.0
-    version: 3.5.40(typescript@4.4.4)
+    version: 3.5.40(typescript@6.0.3)
   vuetify:
     specifier: ^3.1.1
-    version: 3.12.11(typescript@4.4.4)(vue@3.5.40)
+    version: 3.12.11(typescript@6.0.3)(vue@3.5.40)
   vuex:
     specifier: ^4.0.2
     version: 4.1.0(vue@3.5.40)
@@ -28,12 +28,15 @@ dependencies:
     version: 1.6.28
 
 devDependencies:
+  '@types/lodash-es':
+    specifier: ^4.17.12
+    version: 4.17.12
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.10.0
-    version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@4.4.4)
+    version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@6.0.3)
   '@typescript-eslint/parser':
     specifier: ^5.10.0
-    version: 5.62.0(eslint@7.32.0)(typescript@4.4.4)
+    version: 5.62.0(eslint@7.32.0)(typescript@6.0.3)
   '@vitejs/plugin-vue':
     specifier: ^1.2.4
     version: 1.10.2(vite@2.9.18)
@@ -45,7 +48,7 @@ devDependencies:
     version: 7.32.0
   eslint-config-standard-with-typescript:
     specifier: ^21.0.1
-    version: 21.0.1(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.32.0)(eslint-plugin-node@11.1.0)(eslint-plugin-promise@4.3.1)(eslint@7.32.0)(typescript@4.4.4)
+    version: 21.0.1(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.32.0)(eslint-plugin-node@11.1.0)(eslint-plugin-promise@4.3.1)(eslint@7.32.0)(typescript@6.0.3)
   eslint-plugin-import:
     specifier: ^2.22.1
     version: 2.32.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)
@@ -65,11 +68,14 @@ devDependencies:
     specifier: ^1.38.0
     version: 1.102.0
   typescript:
-    specifier: <4.5.0
-    version: 4.4.4
+    specifier: 6.0.3
+    version: 6.0.3
   vite:
     specifier: ^2.9.16
     version: 2.9.18(sass@1.102.0)
+  vue-tsc:
+    specifier: ^3.3.8
+    version: 3.3.8(typescript@6.0.3)
 
 packages:
 
@@ -95,7 +101,6 @@ packages:
   /@babel/helper-string-parser@7.29.7:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helper-validator-identifier@7.29.7:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
@@ -117,7 +122,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.29.7
-    dev: false
 
   /@babel/types@7.29.7:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
@@ -125,7 +129,6 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-    dev: false
 
   /@babylonjs/core@5.57.1:
     resolution: {integrity: sha512-k8U+SFPVGvHgeNr651nxZL26iVCmTzjmRrdbQa0BGas+lg8PIV/tfhN4uTeWWQeRFLvjbkcHA5qD8x/Xk3EpMQ==}
@@ -410,6 +413,16 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
 
+  /@types/lodash-es@4.17.12:
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+    dependencies:
+      '@types/lodash': 4.17.24
+    dev: true
+
+  /@types/lodash@4.17.24:
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+    dev: true
+
   /@types/node@26.1.1:
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
     dependencies:
@@ -420,7 +433,7 @@ packages:
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@4.4.4):
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@6.0.3):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -432,23 +445,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@4.4.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@4.4.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@4.4.4)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.8.5
-      tsutils: 3.21.0(typescript@4.4.4)
-      typescript: 4.4.4
+      tsutils: 3.21.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@4.4.4):
+  /@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@6.0.3):
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -460,15 +473,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.4.4)
+      '@typescript-eslint/typescript-estree': 4.33.0(typescript@6.0.3)
       debug: 4.4.3
       eslint: 7.32.0
-      typescript: 4.4.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.4.4):
+  /@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -480,10 +493,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.4.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
       debug: 4.4.3
       eslint: 7.32.0
-      typescript: 4.4.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -504,7 +517,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@4.4.4):
+  /@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@6.0.3):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -514,12 +527,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.4.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@4.4.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 7.32.0
-      tsutils: 3.21.0(typescript@4.4.4)
-      typescript: 4.4.4
+      tsutils: 3.21.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -534,7 +547,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@4.33.0(typescript@4.4.4):
+  /@typescript-eslint/typescript-estree@4.33.0(typescript@6.0.3):
     resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -549,13 +562,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.8.5
-      tsutils: 3.21.0(typescript@4.4.4)
-      typescript: 4.4.4
+      tsutils: 3.21.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@4.4.4):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@6.0.3):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -570,13 +583,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.8.5
-      tsutils: 3.21.0(typescript@4.4.4)
-      typescript: 4.4.4
+      tsutils: 3.21.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@4.4.4):
+  /@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@6.0.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -587,7 +600,7 @@ packages:
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.4.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       semver: 7.8.5
@@ -621,6 +634,24 @@ packages:
       vite: 2.9.18(sass@1.102.0)
     dev: true
 
+  /@volar/language-core@2.4.28:
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+    dependencies:
+      '@volar/source-map': 2.4.28
+    dev: true
+
+  /@volar/source-map@2.4.28:
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+    dev: true
+
+  /@volar/typescript@2.4.28:
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+    dev: true
+
   /@vue/compiler-core@3.5.40:
     resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
     dependencies:
@@ -629,14 +660,12 @@ packages:
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
-    dev: false
 
   /@vue/compiler-dom@3.5.40:
     resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
     dependencies:
       '@vue/compiler-core': 3.5.40
       '@vue/shared': 3.5.40
-    dev: false
 
   /@vue/compiler-sfc@3.5.40:
     resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
@@ -691,6 +720,18 @@ packages:
       - webpack
     dev: true
 
+  /@vue/language-core@3.3.8:
+    resolution: {integrity: sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==}
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.5
+    dev: true
+
   /@vue/reactivity@3.5.40:
     resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
     dependencies:
@@ -723,7 +764,6 @@ packages:
 
   /@vue/shared@3.5.40:
     resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
-    dev: false
 
   /@webassemblyjs/ast@1.14.1:
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -903,6 +943,10 @@ packages:
       fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+    dev: true
+
+  /alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
     dev: true
 
   /ansi-colors@4.1.3:
@@ -1553,7 +1597,6 @@ packages:
   /entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
-    dev: false
 
   /es-abstract-get@1.0.0:
     resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
@@ -1899,7 +1942,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-standard-with-typescript@21.0.1(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.32.0)(eslint-plugin-node@11.1.0)(eslint-plugin-promise@4.3.1)(eslint@7.32.0)(typescript@4.4.4):
+  /eslint-config-standard-with-typescript@21.0.1(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.32.0)(eslint-plugin-node@11.1.0)(eslint-plugin-promise@4.3.1)(eslint@7.32.0)(typescript@6.0.3):
     resolution: {integrity: sha512-FeiMHljEJ346Y0I/HpAymNKdrgKEpHpcg/D93FvPHWfCzbT4QyUJba/0FwntZeGLXfUiWDSeKmdJD597d9wwiw==}
     deprecated: Please use eslint-config-love, instead.
     peerDependencies:
@@ -1910,14 +1953,14 @@ packages:
       eslint-plugin-promise: ^4.2.1 || ^5.0.0
       typescript: ^3.9 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@4.4.4)
-      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@4.4.4)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@6.0.3)
       eslint: 7.32.0
       eslint-config-standard: 16.0.3(eslint-plugin-import@2.32.0)(eslint-plugin-node@11.1.0)(eslint-plugin-promise@4.3.1)(eslint@7.32.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)
       eslint-plugin-node: 11.1.0(eslint@7.32.0)
       eslint-plugin-promise: 4.3.1
-      typescript: 4.4.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2005,7 +2048,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@4.4.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.10
@@ -2035,7 +2078,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@4.4.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
@@ -2254,7 +2297,6 @@ packages:
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: false
 
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -3040,6 +3082,10 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
+  /muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+    dev: true
+
   /nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3231,6 +3277,10 @@ packages:
     resolution: {integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==}
     dev: true
 
+  /path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: true
+
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -3275,7 +3325,6 @@ packages:
     engines: {node: '>=12'}
     requiresBuild: true
     dev: true
-    optional: true
 
   /possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3887,14 +3936,14 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsutils@3.21.0(typescript@4.4.4):
+  /tsutils@3.21.0(typescript@6.0.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.4.4
+      typescript: 6.0.3
     dev: true
 
   /tty-browserify@0.0.0:
@@ -3958,9 +4007,9 @@ packages:
       reflect.getprototypeof: 1.0.10
     dev: true
 
-  /typescript@4.4.4:
-    resolution: {integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==}
-    engines: {node: '>=4.2.0'}
+  /typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   /unbox-primitive@1.1.0:
@@ -4051,6 +4100,10 @@ packages:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
     dev: true
 
+  /vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+    dev: true
+
   /vue-eslint-parser@8.3.0(eslint@7.32.0):
     resolution: {integrity: sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4069,7 +4122,18 @@ packages:
       - supports-color
     dev: true
 
-  /vue@3.5.40(typescript@4.4.4):
+  /vue-tsc@3.3.8(typescript@6.0.3):
+    resolution: {integrity: sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.8
+      typescript: 6.0.3
+    dev: true
+
+  /vue@3.5.40(typescript@6.0.3):
     resolution: {integrity: sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==}
     peerDependencies:
       typescript: '*'
@@ -4082,10 +4146,10 @@ packages:
       '@vue/runtime-dom': 3.5.40
       '@vue/server-renderer': 3.5.40
       '@vue/shared': 3.5.40
-      typescript: 4.4.4
+      typescript: 6.0.3
     dev: false
 
-  /vuetify@3.12.11(typescript@4.4.4)(vue@3.5.40):
+  /vuetify@3.12.11(typescript@6.0.3)(vue@3.5.40):
     resolution: {integrity: sha512-0qAGQcTbPGv9FN/Yr7kq20UV6djAC0oh2+2BPzZ5Zu8Pw/grNnrKLm3I3/6ZtGF+5IAH6FRGjDw8BZItPjJojw==}
     peerDependencies:
       typescript: '>=4.7'
@@ -4100,8 +4164,8 @@ packages:
       webpack-plugin-vuetify:
         optional: true
     dependencies:
-      typescript: 4.4.4
-      vue: 3.5.40(typescript@4.4.4)
+      typescript: 6.0.3
+      vue: 3.5.40(typescript@6.0.3)
     dev: false
 
   /vuex@4.1.0(vue@3.5.40):
@@ -4110,7 +4174,7 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.40(typescript@4.4.4)
+      vue: 3.5.40(typescript@6.0.3)
     dev: false
 
   /watchpack@2.5.2:

--- a/src/components/game/Creature.vue
+++ b/src/components/game/Creature.vue
@@ -19,7 +19,7 @@
       <text x="50" y="15" class="name annotation" v-text="creatureName" />
       <text x="10" y="90" class="strength annotation" :class="titanStrength" v-text="strength" />
       <text v-if="type === CreatureType.TITAN" x="50" y="83" class="annotation">&ndash;</text>
-      <text x="90" y="90" class="skill annotation" v-text="creature.skill" />
+      <text x="90" y="90" class="skill annotation" v-text="creature?.skill" />
       <g v-if="dead">
         <!-- mdi-skull -->
         <path
@@ -32,10 +32,10 @@
         <text x="50" y="45" class="wounds number annotation" v-text="wounds" />
         <text x="50" y="75" class="wounds label annotation" v-text="`Hit${wounds > 1 ? 's' : ''}`" />
       </g>
-      <g transform="translate(50 82) scale(1.1)" :class="{ 'both-present': creature.canFly && creature.canRangestrike }">
+      <g transform="translate(50 82) scale(1.1)" :class="{ 'both-present': creature?.canFly && creature?.canRangestrike }">
         <!-- icons copied directly from Adobe Illustrator -->
-        <path v-if="creature.canRangestrike" class="icon rangestrike" d="M15,.966A50.386,50.386,0,0,1,6.37,7.9c-.513-1.114,1.262-3.18-1.041-2.533C3.69,5.823-1.16,7.7.394,6.878c-1.229.651.765-1.4,1.281-1.8C3.534,3.625,5.419,2.2,7.39.907c3.288-2.156,1.485.14,1.3.663C8.029,3.462,9.78,3.022,10.9,2.554,12.253,1.99,13.632,1.492,15,.966Z" />
-        <path v-if="creature.canFly" class="icon flight" d="M4.893,0c.213.135.579.238.615.41C5.961,2.6,7.332,3.376,9.462,3.089c.163-.022.363.233.538.354-.2,1.354-1.769,1.507-2.223,2.6-.488,1.18.949,2.191.311,3.4C4.805,9,7.021,6.624,2.054,9.671c-.7-1.337.533-2.388.218-3.51C1.946,5,.328,4.837.013,3.43c-.059-.186.079-.3.445-.333C3.374,2.853,3.373,2.848,4.893,0Z" />
+        <path v-if="creature?.canRangestrike" class="icon rangestrike" d="M15,.966A50.386,50.386,0,0,1,6.37,7.9c-.513-1.114,1.262-3.18-1.041-2.533C3.69,5.823-1.16,7.7.394,6.878c-1.229.651.765-1.4,1.281-1.8C3.534,3.625,5.419,2.2,7.39.907c3.288-2.156,1.485.14,1.3.663C8.029,3.462,9.78,3.022,10.9,2.554,12.253,1.99,13.632,1.492,15,.966Z" />
+        <path v-if="creature?.canFly" class="icon flight" d="M4.893,0c.213.135.579.238.615.41C5.961,2.6,7.332,3.376,9.462,3.089c.163-.022.363.233.538.354-.2,1.354-1.769,1.507-2.223,2.6-.488,1.18.949,2.191.311,3.4C4.805,9,7.021,6.624,2.054,9.671c-.7-1.337.533-2.388.218-3.51C1.946,5,.328,4.837.013,3.43c-.059-.186.079-.3.445-.333C3.374,2.853,3.373,2.848,4.893,0Z" />
       </g>
     </template>
   </component>

--- a/src/components/game/battle/ActiveStrikePanel.vue
+++ b/src/components/game/battle/ActiveStrikePanel.vue
@@ -1,9 +1,9 @@
 <template>
   <v-expand-transition>
-    <v-card v-if="strike" v-bind="$props" width="300">
-      <StrikePanelTitle :attacker="attacker" :target="target" />
+    <v-card v-if="strike" v-bind="$props as any" width="300">
+      <StrikePanelTitle :attacker="attacker!" :target="target!" />
       <v-card-text>
-        {{ activeStrike ? "Rolled " : "" }}{{ strike.dice }} {{ strike === 1 ? "die" : "dice" }},
+        {{ activeStrike ? "Rolled " : "" }}{{ strike.dice }} {{ strike.dice === 1 ? "die" : "dice" }},
         {{ activeStrike ? "needed" : "needing" }} {{ strike.toHit }}s or better to hit.
       </v-card-text>
       <v-card-item v-if="activeStrike" class="pt-1">
@@ -17,7 +17,7 @@
       </v-card-item>
       <v-card-item v-for="([creature, hits], index) in targets" :key="creature.guid">
         {{ index === 0 ? "Dealt" : "Carried over" }} {{ hitsString(hits) }} to a
-        {{ creature.name() }}{{ activeStrike.rangestrike ? " with a rangestrike" : "" }}.
+        {{ creature.name() }}{{ activeStrike?.rangestrike ? " with a rangestrike" : "" }}.
         <span v-if="creature.getRemainingHp() < 1">The {{ creature.name() }} is dead.</span>
       </v-card-item>
       <v-card-text v-if="activeStrike">

--- a/src/components/game/battle/CreaturePanel.vue
+++ b/src/components/game/battle/CreaturePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card v-bind="$props" width="342" :title="minimized ? 'View off-board creatures' : undefined">
+  <v-card v-bind="$props as any" width="342" :title="minimized ? 'View off-board creatures' : undefined">
     <v-btn
       position="absolute"
       location="top right"

--- a/src/components/game/battle/FocusedStrikePanel.vue
+++ b/src/components/game/battle/FocusedStrikePanel.vue
@@ -1,9 +1,9 @@
 <template>
   <v-expand-transition>
-    <v-card v-if="strike" v-bind="$props" width="300">
-      <StrikePanelTitle :attacker="selectedCreature" :target="target ?? rangedTarget" />
+    <v-card v-if="strike" v-bind="$props as any" width="300">
+      <StrikePanelTitle :attacker="selectedCreature" :target="(target ?? rangedTarget)!" />
       <v-card-text>
-        {{ strike.dice }} {{ strike === 1 ? "die" : "dice" }}, needing {{ strike.toHit }}s or better to hit.
+        {{ strike.dice }} {{ strike.dice === 1 ? "die" : "dice" }}, needing {{ strike.toHit }}s or better to hit.
       </v-card-text>
     </v-card>
   </v-expand-transition>

--- a/src/components/game/battle/PendingCreatures.vue
+++ b/src/components/game/battle/PendingCreatures.vue
@@ -22,7 +22,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from "vue"
 import { mapActions, mapGetters, mapMutations, mapState } from "vuex"
-import { BattlePhase } from "~/models/battle"
+import { BattleCreature, BattlePhase } from "~/models/battle"
 import Creature from "../Creature.vue"
 
 export default defineComponent({
@@ -30,7 +30,7 @@ export default defineComponent({
   components: { Creature },
   props: {
     creatures: {
-      type: Array,
+      type: Array as PropType<BattleCreature[]>,
       required: true
     },
     expectedPhase: {

--- a/src/components/game/masterboard/HexEdge.vue
+++ b/src/components/game/masterboard/HexEdge.vue
@@ -64,8 +64,8 @@ export default defineComponent({
         !this.edge.hex.getEdges().some(edge =>
           edge.rule !== MovementRule.NONE && edge.hex.id === this.hex.id)
     },
-    hexTransform() {
-      return hexTransform(this.hex.id)
+    hexTransform(): string {
+      return hexTransform(this.hex.id).toString()
     },
     transform() {
       return `rotate(${isHexInverted(this.hex.id) ? 180 : 0})

--- a/src/components/game/masterboard/Masterboard.vue
+++ b/src/components/game/masterboard/Masterboard.vue
@@ -58,9 +58,10 @@ export default defineComponent({
         stack === this.selectedStack ? 999 : lastSortedStacks.indexOf(stack))
       return lastSortedStacks
     },
-    interleavedPaths(): [boolean, MasterboardHex][] {
+    interleavedPaths(): [boolean, MasterboardHex][][] {
       return range(this.paths[0].path.length).map((colIndex: number) =>
-        this.paths.map((row: Path) => [row.foe !== undefined, row.path[colIndex]])).slice(1)
+        this.paths.map((row: Path): [boolean, MasterboardHex] =>
+          [row.foe !== undefined, row.path[colIndex]])).slice(1)
     },
     canFreeMove(): boolean {
       return this.activePhase === MasterboardPhase.MOVE &&

--- a/src/components/game/masterboard/MasterboardHex.vue
+++ b/src/components/game/masterboard/MasterboardHex.vue
@@ -106,8 +106,8 @@ export default defineComponent({
         [CLIP_TRIANGLE_SIDE / 2 - TRIANGLE_SIDE / 2, TRIANGLE_HEIGHT / 2 - CLIP_TRIANGLE_HEIGHT]
       ].map(([x, y]) => `${x},${y}`)
     },
-    transform() {
-      return hexTransform(this.hex.id)
+    transform(): string {
+      return hexTransform(this.hex.id).toString()
     },
     inverted() {
       return isHexInverted(this.hex.id)

--- a/src/components/ui/game/MusterChoices.vue
+++ b/src/components/ui/game/MusterChoices.vue
@@ -41,13 +41,13 @@
   </div>
 </template>
 <script lang="ts">
-import { defineComponent } from "vue"
+import { defineComponent, PropType } from "vue"
 import { fill } from "lodash-es"
 import { mapState } from "vuex"
 import { CREATURE_DATA } from "~/models/creature"
 import { MasterboardPhase } from "~/models/game"
 import { Player } from "~/models/player"
-import { MusterPossibility } from "~/models/stack"
+import { MusterChoice, MusterPossibility } from "~/models/stack"
 import Creature from "../../game/Creature.vue"
 
 export default defineComponent({
@@ -55,7 +55,7 @@ export default defineComponent({
   components: { Creature },
   props: {
     musterable: {
-      type: Array,
+      type: Array as PropType<MusterPossibility[]>,
       required: false,
       default: () => []
     },
@@ -65,7 +65,7 @@ export default defineComponent({
       default: undefined
     },
     modelValue: {
-      type: Array, // MusterPossibility
+      type: Array as unknown as PropType<MusterChoice>,
       required: false,
       default: undefined
     }
@@ -84,7 +84,7 @@ export default defineComponent({
       get() {
         return this.modelValue
       },
-      set(value: MusterPossibility) {
+      set(value: MusterChoice) {
         this.$emit("update:modelValue", value)
       }
     }
@@ -95,7 +95,7 @@ export default defineComponent({
     }
   },
   methods: {
-    choose(possibility: MusterPossibility) {
+    choose(possibility: MusterChoice) {
       this.chosen = possibility
       fill(this.dialogState, false)
     }

--- a/src/components/ui/game/StackPanel.vue
+++ b/src/components/ui/game/StackPanel.vue
@@ -5,7 +5,7 @@
       border
       width="342"
       subtitle="Hover over a stack to view details..."
-      v-bind="$props"
+      v-bind="$props as any"
     />
     <v-card
       v-else
@@ -13,13 +13,13 @@
       class="root-card"
       border
       width="342"
-      v-bind="$props"
+      v-bind="$props as any"
     >
       <v-card-actions v-if="selectedStack === focusedStack" class="justify-space-between">
         <v-btn @click="cycleStacks(-1)">Previous Stack</v-btn>
         <v-btn @click="cycleStacks(1)">Next Stack</v-btn>
       </v-card-actions>
-      <v-card-item :title="`${stackPlayer.name} (${focusedStack.creatures.length} creatures)`">
+      <v-card-item :title="`${stackPlayer?.name} (${focusedStack.creatures.length} creatures)`">
         <template #prepend>
           <Marker :color="focusedStack.owner" :marker="focusedStack.marker" width="50" height="50" />
         </template>
@@ -27,7 +27,7 @@
 
       <div class="px-2 pb-1">
         <Creature
-          v-for="(creature, index) in focusedStack.creatures"
+          v-for="(creature, index) in (focusedStack.creatures as CreatureType[])"
           :key="index"
           :type="creature"
           :player="stackPlayer"
@@ -54,8 +54,8 @@
             You may select at least 2 and at most {{ focusedStack.creatures.length - 2 }} creatures to split
             into a new stack.
             <div v-if="focusedStack.getCreaturesSplit(true).length > 0" class="text-left mt-5">
-              <p>Remaining: {{ focusedStack.getCreaturesSplit(false).map(c => CREATURES[c].name).join(", ") }}</p>
-              <p>Splitting: {{ focusedStack.getCreaturesSplit(true).map(c => CREATURES[c].name).join(", ") }}</p>
+              <p>Remaining: {{ focusedStack.getCreaturesSplit(false).map((c: CreatureType) => CREATURES[c].name).join(", ") }}</p>
+              <p>Splitting: {{ focusedStack.getCreaturesSplit(true).map((c: CreatureType) => CREATURES[c].name).join(", ") }}</p>
             </div>
           </v-card-text>
         </v-card-actions>
@@ -91,7 +91,7 @@ import { CREATURE_DATA, CreatureType } from "~/models/creature"
 import { MasterboardPhase } from "~/models/game"
 import masterboard, { Terrain } from "~/models/masterboard"
 import { Player } from "~/models/player"
-import { MusterPossibility, Stack } from "~/models/stack"
+import { MusterChoice, MusterPossibility, Stack } from "~/models/stack"
 import { mod } from "~/utils/math"
 import Creature from "../../game/Creature.vue"
 import Marker from "../../game/Marker.vue"
@@ -130,7 +130,7 @@ export default defineComponent({
       get() {
         return this.focusedStack?.currentMuster
       },
-      set(value: MusterPossibility) {
+      set(value: MusterChoice) {
         if (this.activePhase !== MasterboardPhase.MUSTER) {
           return
         }

--- a/src/components/ui/game/TurnPanel.vue
+++ b/src/components/ui/game/TurnPanel.vue
@@ -80,6 +80,7 @@
 import { defineComponent } from "vue"
 import { sum } from "lodash-es"
 import { mapActions, mapGetters, mapMutations, mapState } from "vuex"
+import DiceRoller from "~/components/ui/generic/DiceRoller"
 import { MasterboardPhase } from "~/models/game"
 import { Stack } from "~/models/stack"
 
@@ -134,7 +135,8 @@ export default defineComponent({
       if (this.activeRoll !== undefined) {
         this.setRoll(undefined)
       }
-      this.diceRoller.roll().then(async(roll: number[]) => await this.setRoll(roll[0]))
+      const diceRoller = this.diceRoller as InstanceType<typeof DiceRoller>
+      diceRoller.roll().then(async(roll: number[]) => await this.setRoll(roll[0]))
     },
     proceedToRoll() {
       this.deselectStack()

--- a/src/components/ui/generic/DiceRoller.vue
+++ b/src/components/ui/generic/DiceRoller.vue
@@ -7,14 +7,15 @@
 <script lang="ts">
 import DiceBox from "@3d-dice/dice-box"
 import { defineComponent } from "vue"
-import { random, range, set } from "lodash-es"
+import { random, range } from "lodash-es"
 import { mapState } from "vuex"
 
 interface ComponentData {
   ready: boolean,
   rolling: boolean,
   resolve?: (_: number[]) => void,
-  reject?: (_: Error) => void
+  reject?: (_: Error) => void,
+  diceBox?: DiceBox
 }
 
 const DebugDice: { nextRolls?: number[] } = {
@@ -30,7 +31,8 @@ export default defineComponent({
       ready: false,
       rolling: false,
       resolve: undefined,
-      reject: undefined
+      reject: undefined,
+      diceBox: undefined
     }
   },
   computed: {
@@ -61,11 +63,11 @@ export default defineComponent({
       this.resolve = undefined
       this.rolling = false
     }
-    set(this, "diceBox", diceBox)
+    this.diceBox = diceBox
   },
   methods: {
-    async roll(quantity?: number) {
-      return new Promise((resolve, reject) => {
+    async roll(quantity?: number): Promise<number[]> {
+      return new Promise<number[]>((resolve, reject) => {
         if (DebugDice.nextRolls) {
           return resolve(DebugDice.nextRolls)
         }
@@ -79,7 +81,7 @@ export default defineComponent({
         try {
           this.rolling = true
           this.$forceUpdate()
-          this.diceBox.roll(`${quantity ?? 1}d6`)
+          this.diceBox?.roll(`${quantity ?? 1}d6`)
           if (this.quickDice) {
             setTimeout(() => {
               this.resolve?.(range(quantity ?? 1).map(i => random(1, 6)))

--- a/src/components/ui/menus/SystemMenu.vue
+++ b/src/components/ui/menus/SystemMenu.vue
@@ -78,6 +78,7 @@
 <script lang="ts">
 import { defineComponent } from "vue"
 import { mapActions, mapGetters, mapMutations, mapState } from "vuex"
+import DiceRoller from "~/components/ui/generic/DiceRoller"
 import { Creature, CREATURE_LIST } from "~/models/creature"
 import { CreatureColorMode } from "~/store/ui/preferences"
 
@@ -156,7 +157,8 @@ export default defineComponent({
       }
     },
     roll() {
-      this.diceRoller.roll(this.diceQuantity)
+      const diceRoller = this.diceRoller as InstanceType<typeof DiceRoller>
+      diceRoller.roll(this.diceQuantity)
     },
     async persistToClipboard() {
       const value = await this.persist()

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,4 @@ const app = createApp(App)
   .use(vuetify)
   .use(vuex)
 
-app.config.unwrapInjectedRef = true
-
 app.mount("#app")

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -7,7 +7,7 @@ import { Battle, BATTLE_PHASE_TYPES, BattleCreature, BattlePhaseType, Rangestrik
 import { CREATURE_DATA, CREATURE_LIST, CreatureType } from "./creature"
 import masterboard, { HexEdge, MasterboardHex } from "./masterboard"
 import { Player, PlayerId } from "./player"
-import { MusterPossibility, Stack } from "./stack"
+import { MusterChoice, Stack } from "./stack"
 
 const INITIAL_HEXES: Record<number, number[]> = {
   2: [100, 400],
@@ -54,7 +54,7 @@ interface Getters {
 
 interface MovePayload { stack: Stack, hex: number | MasterboardHex, edge?: HexEdge }
 interface BattleMovePayload { creature: BattleCreature, hex: number }
-interface MusterPayload { stack: Stack, recruit: MusterPossibility }
+interface MusterPayload { stack: Stack, recruit: MusterChoice }
 interface BattlePayload { attacking: Stack, defending: Stack }
 interface IStrikePayload { attacker: BattleCreature, rolls: number[] }
 interface AttackPayload extends IStrikePayload { target: BattleCreature, optionalToHit?: number }

--- a/src/models/stack.ts
+++ b/src/models/stack.ts
@@ -7,19 +7,22 @@ import { PlayerId } from "./player"
 export type StackRef = number
 
 export type MusterBasis = [CreatureType, number]
+// One recruitable creature and the ways it can currently be mustered.
 export type MusterPossibility = [CreatureType, MusterBasis[]]
+// A recruit that has actually been chosen: the creature and the single basis used to muster it.
+export type MusterChoice = [CreatureType, MusterBasis]
 
 export class Stack {
   readonly owner: PlayerId
   readonly creatures: CreatureType[]
   readonly marker: number
   readonly split: boolean[]
-  readonly recruits: Record<number, MusterPossibility>
+  readonly recruits: Record<number, MusterChoice>
 
   origin: number
   hex: number
   attackEdge: HexEdge | undefined
-  currentMuster: MusterPossibility | undefined
+  currentMuster: MusterChoice | undefined
 
   constructor(owner: PlayerId, start: number, marker: number, initial?: CreatureType[]) {
     this.owner = owner

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -23,7 +23,7 @@ const titanColors = {
 
 const playerColors = Object.fromEntries(map(titanColors,
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-  (color, name) => [`player-${PlayerId[name.split("-")[1].toUpperCase()]}`, color])
+  (color, name) => [`player-${PlayerId[name.split("-")[1].toUpperCase() as keyof typeof PlayerId]}`, color])
   .filter(entry => entry[0] !== "player-undefined"))
 
 // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,0 +1,24 @@
+declare module "*.css"
+declare module "vuetify/styles"
+
+// src/main.ts patches every object with a lazily-assigned unique id, used as
+// a stable v-for :key for model instances that don't carry their own id.
+interface Object {
+  __guid?: number
+  guid: number
+}
+
+declare module "assert" {
+  function assert(value: unknown, message?: string | Error): asserts value
+  export = assert
+}
+
+declare module "@3d-dice/dice-box" {
+  export default class DiceBox {
+    constructor(selector: string, options?: Record<string, unknown>)
+    init(): Promise<void>
+    roll(notation: string): void
+    onRollComplete: () => void
+    rollData: Array<{ rolls: Array<{ result: number }> }>
+  }
+}

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,4 +1,4 @@
-import * as assertBuiltin from "assert"
+import assertBuiltin from "assert"
 
 export function assert(condition: boolean, msg: string): asserts condition {
   if (typeof assertBuiltin === "function") {

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -218,7 +218,6 @@ function strToUTF8Arr(sDOMStr: string): Uint8Array {
 }
 
 export async function compressAndEncode(stringified: string): Promise<string | undefined> {
-  // @ts-expect-error
   if (window.CompressionStream !== undefined) {
     const stringStream = new ReadableStream({
       start(controller) {
@@ -227,7 +226,6 @@ export async function compressAndEncode(stringified: string): Promise<string | u
         controller.close()
       }
     })
-    // @ts-expect-error
     const compressedStream = stringStream.pipeThrough(new CompressionStream("gzip"))
     const reader = compressedStream.getReader()
     const result = { value: new Uint8Array(0), done: false }
@@ -239,13 +237,12 @@ export async function compressAndEncode(stringified: string): Promise<string | u
       result.done = read.done
       result.value = newValue
     }
-    return base64ArrayBuffer(result.value)
+    return base64ArrayBuffer(result.value.buffer)
   }
 }
 
 export async function decodeAndDecompress(encoded: string): Promise<string | undefined> {
   const binArray = base64DecToArr(encoded)
-  // @ts-expect-error
   if (window.DecompressionStream === undefined) {
     throw new Error("Unable to decompress, DecompressionStream API missing")
   }
@@ -255,7 +252,6 @@ export async function decodeAndDecompress(encoded: string): Promise<string | und
       controller.close()
     }
   })
-  // @ts-expect-error
   const compressedStream = binStream.pipeThrough(new DecompressionStream("gzip"))
   const reader = compressedStream.getReader()
   const result = { value: "", done: false }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,16 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0",
     "lib": ["esnext", "dom", "dom.iterable"],
     "strict": true,
     "jsx": "preserve",
-    "baseUrl": ".",
+    "allowJs": true,
     "paths": {
+      "~/*": [
+        "./src/*"
+      ],
       "~/components/*": [
         "./src/components/*.vue"
       ],
@@ -26,8 +31,6 @@
         "./src/*"
       ]
     },
-    "declaration": true,
-    "declarationMap": true,
     "sourceMap": true,
     "skipLibCheck": true,
     "esModuleInterop": true


### PR DESCRIPTION
TypeScript is pinned below 4.5 with no typecheck script anywhere, so type errors have never been caught in this codebase.

TypeScript 7 (the current major) ships a native compiler with no public Compiler API until 7.1, which [vue-tsc](https://github.com/vuejs/language-tools) depends on and can't yet support for checking `.vue` SFCs ([tracking issue](https://github.com/vuejs/language-tools/issues/5381)), so this targets the latest TS6 release instead and adds `yarn typecheck` (`vue-tsc --noEmit`).

Running it for the first time surfaced real bugs alongside config gaps:
- A strike-die-count comparison against the wrong operand (`strike === 1` instead of `strike.dice === 1`) in [`ActiveStrikePanel.vue`](https://github.com/aolkin/warlord/blob/main/src/components/game/battle/ActiveStrikePanel.vue) and `FocusedStrikePanel.vue`, which meant "die"/"dice" pluralization was always wrong.
- A stale `app.config.unwrapInjectedRef` flag in `main.ts` that Vue 3.5 no longer reads (the behavior it toggled is unconditional now).
- A `MusterPossibility` type in [`stack.ts`](https://github.com/aolkin/warlord/blob/main/src/models/stack.ts) that conflated "the list of ways to muster a creature" with "the one basis actually chosen," used inconsistently across `stack.ts`, `game.ts`, and the muster UI. Split into `MusterPossibility` (the list) and a new `MusterChoice` (the pick).

Also drops the `declaration`/`declarationMap` tsconfig options, which have no consumer in this Vite app and only made vue-tsc demand exports for component-internal types that were never meant to be public.

CI doesn't run typecheck yet — that's a follow-up once this lands.