### PR TITLE
Fix deepFreeze stack overflow on cyclic masterboard hex graph

### DIFF
--- a/src/models/masterboard.ts
+++ b/src/models/masterboard.ts
@@ -7,16 +7,23 @@ import { div, mod } from "~/utils/math"
  * Recursively freeze an object and all its nested properties.
  * Handles Maps, objects, and nested structures.
  */
-function deepFreeze<T>(obj: T): T {
+function deepFreeze<T>(obj: T, seen: WeakSet<object> = new WeakSet()): T {
   if (obj === null || typeof obj !== 'object') {
     return obj
   }
+
+  // Reference cycles (e.g. MasterboardHex.addEdge linking hexes back to each
+  // other) would otherwise cause unbounded recursion here.
+  if (seen.has(obj)) {
+    return obj
+  }
+  seen.add(obj)
 
   // Maps don't enumerate values like objects, so iterate explicitly
   if (obj instanceof Map) {
     Object.freeze(obj)
     obj.forEach((value) => {
-      deepFreeze(value)
+      deepFreeze(value, seen)
     })
     return obj
   }
@@ -25,7 +32,7 @@ function deepFreeze<T>(obj: T): T {
   Object.getOwnPropertyNames(obj).forEach((prop) => {
     const value = (obj as Record<string, unknown>)[prop]
     if (value !== null && (typeof value === 'object' || typeof value === 'function')) {
-      deepFreeze(value)
+      deepFreeze(value, seen)
     }
   })
 


### PR DESCRIPTION
The app white-screens on load: [`deepFreeze`](https://github.com/aolkin/warlord/blob/main/src/models/masterboard.ts) recurses into every property of every object it touches with no record of what it has already visited. [`MasterboardHex.addEdge`](https://github.com/aolkin/warlord/blob/main/src/models/masterboard.ts) creates bidirectional edge references between neighboring hexes, so `deepFreeze(new Masterboard())` at module load recurses forever on that cycle and overflows the stack.

`deepFreeze` now tracks visited objects in a `WeakSet` and skips re-recursing into anything already seen, so each reachable object is still frozen exactly once but traversal terminates on cycles.