### PR TITLE
Inject Random seam into TitanGame's player color assignment

### DIFF
--- a/src/models/game.test.ts
+++ b/src/models/game.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { PlayerId } from "~/models/player"
+import { Random } from "~/models/random"
+import { TitanGame } from "./game"
+
+describe("TitanGame", () => {
+  it("assigns player colors via the injected Random instead of a fixed order", () => {
+    const reverse: Random = {
+      shuffle: collection => [...collection].reverse()
+    }
+
+    const game = new TitanGame(2, reverse)
+
+    expect(game.players.map(player => player.id)).toEqual([PlayerId.BLACK, PlayerId.YELLOW])
+  })
+})

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -1,4 +1,4 @@
-import { assign, matches, range, shuffle } from "lodash-es"
+import { assign, matches, range } from "lodash-es"
 import { BaseActionContext } from "~/store/types"
 import { View } from "~/store/ui/selection"
 import { assert } from "~/utils/assert"
@@ -7,6 +7,7 @@ import { Battle, BATTLE_PHASE_TYPES, BattleCreature, BattlePhaseType, Rangestrik
 import { CREATURE_DATA, CREATURE_LIST, CreatureType } from "./creature"
 import masterboard, { HexEdge, MasterboardHex } from "./masterboard"
 import { Player, PlayerId } from "./player"
+import { defaultRandom, Random } from "./random"
 import { MusterChoice, Stack } from "./stack"
 
 const INITIAL_HEXES: Record<number, number[]> = {
@@ -79,14 +80,14 @@ export class TitanGame {
   activePhase: MasterboardPhase
   activeBattle?: Battle
 
-  constructor(numPlayers: number) {
+  constructor(numPlayers: number, random: Random = defaultRandom) {
     this.round = 0
     this.mulliganTaken = false
     this.activePlayer = 0
     this.activeRoll = undefined
     this.activeBattle = undefined
     this.activePhase = MasterboardPhase.SPLIT
-    const colors = shuffle(range(0, 5))
+    const colors = random.shuffle(range(0, 5))
     this.players = range(0, numPlayers).map(i => new Player(colors[i], `Player ${i + 1}`))
     this.stacks = this.players.map((player: Player, i: number) =>
       new Stack(player?.id, INITIAL_HEXES[numPlayers][i], 0))

--- a/src/models/random.ts
+++ b/src/models/random.ts
@@ -1,0 +1,13 @@
+import { shuffle } from "lodash-es"
+
+/**
+ * Seam for gameplay-relevant randomness, so callers (tests, multiplayer's shared-seed
+ * requirement) can swap in a deterministic implementation instead of Math.random.
+ */
+export interface Random {
+  shuffle<T>(collection: readonly T[]): T[]
+}
+
+export const defaultRandom: Random = {
+  shuffle: collection => shuffle(collection)
+}


### PR DESCRIPTION
`TitanGame`'s constructor now takes an optional `random: Random = defaultRandom` parameter, used in place of the direct `shuffle()` call for player color/turn-order assignment. `src/models/random.ts` defines the `Random` interface and a `defaultRandom` backed by lodash-es's `shuffle`, giving callers (tests, and eventually multiplayer's shared-seed needs) a seam to swap in a deterministic implementation.

This reapplies the RNG seam from #62, which was built on the now-abandoned split of `game.ts` from #61; it's rebased here directly onto the monolithic `src/models/game.ts` on `main`.