### PR TITLE
Bump upload-pages-artifact and deploy-pages actions to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
       #     cmd: build # will run `yarn build` command
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -101,4 +101,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Updates `actions/upload-pages-artifact` from v1 to v5 and `actions/deploy-pages` from v1 to v5. The v1 versions had a dependency on the deprecated `actions/upload-artifact@v3`, causing GitHub Actions to auto-fail the workflow on every push to main.

Both actions have been bumped to their current major version (v5.0.0), which use non-deprecated artifact handling and are compatible with each other.