### PR TITLE
Add characterization tests for battle engine movement, striking, and phases

### DIFF
--- a/src/models/battle/engine.test.ts
+++ b/src/models/battle/engine.test.ts
@@ -399,17 +399,20 @@ describe("Movement legality (movementFor)", () => {
   it("lets a flying creature path through hexes blocked for grounded creatures, reaching further", () => {
     // Battle-hex 2 has only three neighbors (3, 7, 8); occupying both 7 and 8 seals off
     // everything past them for a grounded mover, since creatureMovementCost treats an
-    // occupied non-own hex as UNATTAINABLE for pathing (not just landing) unless flying.
+    // occupied hex as UNATTAINABLE for pathing (not just landing) unless flying - regardless
+    // of which player occupies it. The blockers are on the SAME side as the movers (rather
+    // than the enemy) so the movers aren't in contact with an enemy at phase start; movementFor
+    // doesn't enforce rule 11.3 (in-contact creatures may not move - see the TODO on
+    // movementFor in engine.ts), but this test isn't about that gap.
     const attacking: BattleSide = {
-      player: PlayerId.RED, score: 0, creatures: [CreatureType.CENTAUR, CreatureType.GRIFFON]
+      player: PlayerId.RED,
+      score: 0,
+      creatures: [CreatureType.CENTAUR, CreatureType.GRIFFON, CreatureType.LION, CreatureType.LION]
     }
-    const defending: BattleSide = {
-      player: PlayerId.BLUE, score: 0, creatures: [CreatureType.LION, CreatureType.LION]
-    }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
     const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_MOVE
-    const [centaur, griffon] = battle.getOffense()
-    const [blocker1, blocker2] = battle.getDefense()
+    const [centaur, griffon, blocker1, blocker2] = battle.getOffense()
     centaur.hex = 2
     centaur.initialHex = 2
     griffon.hex = 2
@@ -431,10 +434,11 @@ describe("Movement legality (movementFor)", () => {
 })
 
 describe("Engagement edge cases", () => {
-  it("makes engagement across a cliff direction-dependent: the creature atop it is engaged, the one below is not", () => {
+  it("does not engage a creature below a cliff with the creature above it", () => {
     // Terrain.DESERT's battle board has a cliff edge between battle-hexes 15 and 20.
-    // engagedWith checks getEdgeHazard(whom.hex, candidate.hex), which is keyed by
-    // (lower, upper) - so the check only fires from one side.
+    // This direction of the check (queried from the creature below, looking up) happens
+    // to work correctly - see the TODO on engagedWith's cliff check in engine.ts for the
+    // direction that doesn't.
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.CENTAUR] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.LION] }
     const battle = new Battle(Terrain.DESERT, HexEdge.FIRST, attacking, defending)
@@ -446,8 +450,26 @@ describe("Engagement edge cases", () => {
     lion.hex = 20 // below the cliff
     lion.initialHex = 20
 
-    expect(battle.engagedWith(centaur)).toEqual([lion])
     expect(battle.engagedWith(lion)).toEqual([])
+  })
+
+  // TODO: engagedWith's cliff check is direction-asymmetric (see the TODO at engine.ts's
+  // engagedWith). Per the Hazard Chart and rule 13.5, a cliff blocks engagement symmetrically -
+  // neither creature should be engaged with the other. This documents the correct behavior and
+  // is expected to fail (via it.fails) until that asymmetry is fixed.
+  it.fails("does not engage a creature atop a cliff with the creature below it", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.CENTAUR] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.LION] }
+    const battle = new Battle(Terrain.DESERT, HexEdge.FIRST, attacking, defending)
+    battle.phase = BattlePhase.ATTACKER_STRIKE
+    const centaur = battle.getOffense()[0]
+    const lion = battle.getDefense()[0]
+    centaur.hex = 15 // atop the cliff
+    centaur.initialHex = 15
+    lion.hex = 20 // below the cliff
+    lion.initialHex = 20
+
+    expect(battle.engagedWith(centaur)).toEqual([])
   })
 
   it("checks engagement using the pre-move position while still in a move phase", () => {
@@ -529,10 +551,13 @@ describe("Engagement edge cases", () => {
 
     const targets = battle.rangestrikeTargets(ranger)
     expect(targets).toHaveLength(1)
-    battle.rangestrike(ranger, targets[0], [6, 6, 6, 6])
+    // Ranger has strength 4, so per rule 12.2 (dice = floor(power / 2)) a rangestrike rolls
+    // exactly 2 dice.
+    expect(battle.getRangestrike(ranger, targets[0]).dice).toBe(2)
+    battle.rangestrike(ranger, targets[0], [6, 6])
 
     expect(ranger.hasStruck).toBe(true)
-    expect(centaur.wounds).toBe(3) // capped at Centaur's full strength
+    expect(centaur.wounds).toBe(2)
     expect(battle.activeStrike?.rangestrike).toBe(true)
     expect(battle.activeStrike?.canCarryover).toBe(false) // overkilled, but rangestrikes never carry over
   })

--- a/src/models/battle/engine.test.ts
+++ b/src/models/battle/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { CreatureType } from "~/models/creature"
+import { CREATURE_DATA, CreatureType } from "~/models/creature"
 import { HexEdge, Terrain } from "~/models/masterboard"
 import { PlayerId } from "~/models/player"
 import { UNATTAINABLE_MOVEMENT_COST } from "./board"
@@ -290,5 +290,378 @@ describe("Battle board movement cost", () => {
 
     expect(battle.creatureMovementCost(8, 2, troll)).toBe(1)
     expect(battle.creatureMovementCost(8, 2, centaur)).toBe(UNATTAINABLE_MOVEMENT_COST)
+  })
+
+  it("blocks a volcano hazard for non-native creatures even if they can fly", () => {
+    // Terrain.MOUNTAINS' battle board has a volcano hazard at battle-hex 15 (only
+    // Dragons are volcano-native). Unlike bog and tree, the volcano case in
+    // creatureMovementCost has no `|| canFly` escape hatch.
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.GRIFFON] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.MOUNTAINS, HexEdge.FIRST, attacking, defending)
+    const griffon = battle.getOffense()[0]
+
+    expect(CREATURE_DATA[CreatureType.GRIFFON].canFly).toBe(true)
+    expect(battle.creatureMovementCost(15, 9, griffon)).toBe(UNATTAINABLE_MOVEMENT_COST)
+  })
+
+  it("lets a flying creature cross a tree hex without stopping, but never land in it", () => {
+    // Terrain.WOODS' battle board has a tree hazard at battle-hex 3. Trees have no
+    // native creatures, but the movement-cost switch still waives the block for flyers
+    // (`native || canFly`); creatureCanLand blocks trees unconditionally regardless of flight.
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.GRIFFON] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.WOODS, HexEdge.FIRST, attacking, defending)
+    const griffon = battle.getOffense()[0]
+    const centaur = battle.getDefense()[0]
+
+    expect(battle.creatureMovementCost(3, 2, griffon)).toBe(1)
+    expect(battle.creatureCanLand(3, griffon)).toBe(false)
+    expect(battle.creatureMovementCost(3, 2, centaur)).toBe(UNATTAINABLE_MOVEMENT_COST)
+  })
+
+  it("charges an extra movement point to cross a slope uphill unless edge-native, but never downhill", () => {
+    // Terrain.HILLS' battle board has battle-hex 2 elevated above (and slope-edged
+    // with) battle-hex 3. Ogres are slope-native, Centaurs are not.
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.OGRE] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.HILLS, HexEdge.FIRST, attacking, defending)
+    const ogre = battle.getOffense()[0]
+    const centaur = battle.getDefense()[0]
+
+    expect(battle.creatureMovementCost(2, 3, ogre)).toBe(1) // uphill, native: no penalty
+    expect(battle.creatureMovementCost(2, 3, centaur)).toBe(2) // uphill, non-native: +1
+    expect(battle.creatureMovementCost(3, 2, centaur)).toBe(1) // downhill: no penalty regardless
+  })
+
+  it("charges an extra movement point to cross a wall in one direction only, regardless of native status", () => {
+    // Terrain.TOWER's battle board has a wall edge between battle-hexes 2 (elevation 0)
+    // and 8 (elevation 1). EDGE_HAZARD_NATIVES has no wall entries, so the penalty
+    // applies to every creature type crossing upward.
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.CENTAUR] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.OGRE] }
+    const battle = new Battle(Terrain.TOWER, HexEdge.FIRST, attacking, defending)
+    const centaur = battle.getOffense()[0]
+
+    expect(battle.creatureMovementCost(8, 2, centaur)).toBe(2) // upward, across the wall
+    expect(battle.creatureMovementCost(2, 8, centaur)).toBe(1) // downward: no penalty
+  })
+
+  it("makes a cliff edge impassable in both directions, unlike walls and slopes", () => {
+    // Terrain.DESERT's battle board has a cliff edge between battle-hexes 15 and 20.
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.CENTAUR] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.OGRE] }
+    const battle = new Battle(Terrain.DESERT, HexEdge.FIRST, attacking, defending)
+    const centaur = battle.getOffense()[0]
+
+    expect(battle.creatureMovementCost(15, 20, centaur)).toBe(UNATTAINABLE_MOVEMENT_COST)
+    expect(battle.creatureMovementCost(20, 15, centaur)).toBe(UNATTAINABLE_MOVEMENT_COST)
+  })
+})
+
+describe("Movement legality (movementFor)", () => {
+  it("returns an empty set for a creature that is not on the board", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    const lion = battle.getOffense()[0]
+    lion.initialHex = 0
+
+    expect(battle.movementFor(lion)).toEqual(new Set())
+  })
+
+  it("reaches exactly the hexes affordable within a creature's skill, on hazard-free terrain", () => {
+    // Ogre (skill 2) entering from battle-hex 37 (the attacker's entrance zone on
+    // HexEdge.FIRST), on hazard-free Plains: every hex within 2 movement points.
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.OGRE] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    battle.phase = BattlePhase.ATTACKER_MOVE
+    const ogre = battle.getOffense()[0]
+    expect(ogre.initialHex).toBe(37)
+
+    expect(battle.movementFor(ogre)).toEqual(new Set([3, 4, 9, 10, 16, 17, 22, 23, 29]))
+  })
+
+  it("cannot land a stack on a hex already occupied by another creature (friend or foe)", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    battle.phase = BattlePhase.ATTACKER_MOVE
+    const lion = battle.getOffense()[0]
+    const centaur = battle.getDefense()[0]
+    centaur.hex = 4
+    centaur.initialHex = 4
+
+    expect(battle.movementFor(lion).has(4)).toBe(false)
+  })
+
+  it("lets a flying creature path through hexes blocked for grounded creatures, reaching further", () => {
+    // Battle-hex 2 has only three neighbors (3, 7, 8); occupying both 7 and 8 seals off
+    // everything past them for a grounded mover, since creatureMovementCost treats an
+    // occupied non-own hex as UNATTAINABLE for pathing (not just landing) unless flying.
+    const attacking: BattleSide = {
+      player: PlayerId.RED, score: 0, creatures: [CreatureType.CENTAUR, CreatureType.GRIFFON]
+    }
+    const defending: BattleSide = {
+      player: PlayerId.BLUE, score: 0, creatures: [CreatureType.LION, CreatureType.LION]
+    }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    battle.phase = BattlePhase.ATTACKER_MOVE
+    const [centaur, griffon] = battle.getOffense()
+    const [blocker1, blocker2] = battle.getDefense()
+    centaur.hex = 2
+    centaur.initialHex = 2
+    griffon.hex = 2
+    griffon.initialHex = 2
+    blocker1.hex = 7
+    blocker1.initialHex = 7
+    blocker2.hex = 8
+    blocker2.initialHex = 8
+
+    const centaurReach = battle.movementFor(centaur)
+    const griffonReach = battle.movementFor(griffon)
+    expect(centaurReach).toEqual(new Set([3, 4, 9, 10, 14, 15, 16, 17, 20, 21, 22]))
+    expect(griffonReach).toEqual(new Set([
+      3, 4, 9, 10, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 25, 26, 27, 28
+    ]))
+    // Every hex the grounded Centaur can still reach (via hex 3), the flying Griffon can too.
+    centaurReach.forEach(hex => expect(griffonReach.has(hex)).toBe(true))
+  })
+})
+
+describe("Engagement edge cases", () => {
+  it("makes engagement across a cliff direction-dependent: the creature atop it is engaged, the one below is not", () => {
+    // Terrain.DESERT's battle board has a cliff edge between battle-hexes 15 and 20.
+    // engagedWith checks getEdgeHazard(whom.hex, candidate.hex), which is keyed by
+    // (lower, upper) - so the check only fires from one side.
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.CENTAUR] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.LION] }
+    const battle = new Battle(Terrain.DESERT, HexEdge.FIRST, attacking, defending)
+    battle.phase = BattlePhase.ATTACKER_STRIKE
+    const centaur = battle.getOffense()[0]
+    const lion = battle.getDefense()[0]
+    centaur.hex = 15 // atop the cliff
+    centaur.initialHex = 15
+    lion.hex = 20 // below the cliff
+    lion.initialHex = 20
+
+    expect(battle.engagedWith(centaur)).toEqual([lion])
+    expect(battle.engagedWith(lion)).toEqual([])
+  })
+
+  it("checks engagement using the pre-move position while still in a move phase", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    const centaur = battle.getDefense()[0]
+
+    expect(battle.phase).toBe(BattlePhase.DEFENDER_MOVE)
+    centaur.hex = 7 // now adjacent to where the Lion will eventually stand (hex 8)
+    // Still using centaur.initialHex (the entrance zone) for the engagement check, since
+    // we haven't left the move phase - the newly-occupied hex 7 has no bearing yet.
+    expect(battle.engagedWith(centaur)).toEqual([])
+  })
+
+  it("excludes an engaged creature from carryover if the attacker cannot hit it at the toHit it just rolled", () => {
+    // Terrain.TOWER's battle board has battle-hex 8 atop a wall edge from battle-hex 2,
+    // which raises toHit by 1 for an attacker striking up through it.
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = {
+      player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR, CreatureType.CENTAUR, CreatureType.CENTAUR]
+    }
+    const battle = new Battle(Terrain.TOWER, HexEdge.FIRST, attacking, defending)
+    battle.phase = BattlePhase.ATTACKER_STRIKE
+    const lion = battle.getOffense()[0]
+    const [primary, included, excluded] = battle.getDefense()
+    lion.hex = 2
+    lion.initialHex = 2
+    primary.hex = 7 // toHit 5, no hazard - struck directly, overkilled
+    primary.initialHex = 7
+    included.hex = 3 // toHit 5, no hazard - matches the rolled toHit, so carryover-eligible
+    included.initialHex = 3
+    excluded.hex = 8 // toHit 6, raised by the wall - harder than the rolled toHit
+    excluded.initialHex = 8
+
+    expect(battle.toHitAdjusted(lion, primary)).toBe(5)
+    expect(battle.toHitAdjusted(lion, included)).toBe(5)
+    expect(battle.toHitAdjusted(lion, excluded)).toBe(6)
+
+    battle.strike(lion, primary, [6, 6, 6, 6, 6])
+    expect(primary.getRemainingHp()).toBe(0) // overkilled, so it drops out of engagedWith too
+    expect(battle.carryoverTargets()).toEqual([included])
+  })
+
+  it("lets a strike choose a higher toHit than computed, but rejects a lower one", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    battle.phase = BattlePhase.ATTACKER_STRIKE
+    const lion = battle.getOffense()[0]
+    const centaur = battle.getDefense()[0]
+    lion.hex = 8
+    lion.initialHex = 8
+    centaur.hex = 7
+    centaur.initialHex = 7
+
+    const computedToHit = battle.toHitAdjusted(lion, centaur)
+    expect(computedToHit).toBe(5)
+    expect(() => battle.strike(lion, centaur, [6, 6, 6, 6, 6], computedToHit - 1))
+      .toThrow("Cannot choose a lower to-hit")
+
+    battle.strike(lion, centaur, [6, 6, 6, 6, 6], computedToHit + 1)
+    expect(battle.activeStrike?.toHit).toBe(computedToHit + 1)
+    // A roll of 6 still clears the raised toHit of 6, so all 5 dice hit (capped at HP 3).
+    expect(centaur.wounds).toBe(3)
+  })
+
+  it("resolves a rangestrike attack the same way as a melee strike, but never allows carryover", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    battle.phase = BattlePhase.ATTACKER_STRIKE
+    const ranger = battle.getOffense()[0]
+    const centaur = battle.getDefense()[0]
+    ranger.hex = 8
+    ranger.initialHex = 8
+    centaur.hex = 20
+    centaur.initialHex = 20
+
+    const targets = battle.rangestrikeTargets(ranger)
+    expect(targets).toHaveLength(1)
+    battle.rangestrike(ranger, targets[0], [6, 6, 6, 6])
+
+    expect(ranger.hasStruck).toBe(true)
+    expect(centaur.wounds).toBe(3) // capped at Centaur's full strength
+    expect(battle.activeStrike?.rangestrike).toBe(true)
+    expect(battle.activeStrike?.canCarryover).toBe(false) // overkilled, but rangestrikes never carry over
+  })
+})
+
+describe("Battle phase transitions", () => {
+  it("cycles through all six phases in order for a continuously-engaged pair, incrementing round only after defender strikeback", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    const lion = battle.getOffense()[0]
+    const centaur = battle.getDefense()[0]
+    centaur.hex = 7
+    centaur.initialHex = 7
+    lion.hex = 8
+    lion.initialHex = 8
+
+    const expectPhase = (phase: BattlePhase, round: number): void => {
+      expect(battle.phase).toBe(phase)
+      expect(battle.round).toBe(round)
+    }
+    expectPhase(BattlePhase.DEFENDER_MOVE, 0)
+
+    battle.nextPhase()
+    expectPhase(BattlePhase.DEFENDER_STRIKE, 0)
+    centaur.performStrike() // stand in for an actual strike() call - only hasStruck matters here
+
+    battle.nextPhase()
+    expectPhase(BattlePhase.ATTACKER_STRIKEBACK, 0)
+    lion.performStrike()
+
+    battle.nextPhase()
+    expectPhase(BattlePhase.ATTACKER_MOVE, 0)
+
+    battle.nextPhase()
+    expectPhase(BattlePhase.ATTACKER_STRIKE, 0)
+    lion.performStrike()
+
+    battle.nextPhase()
+    expectPhase(BattlePhase.DEFENDER_STRIKEBACK, 0)
+    centaur.performStrike()
+
+    battle.nextPhase()
+    expectPhase(BattlePhase.DEFENDER_MOVE, 1)
+  })
+
+  it("skips straight past strike and strikeback phases when nobody is engaged", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+
+    expect(battle.phase).toBe(BattlePhase.DEFENDER_MOVE)
+    battle.nextPhase() // no engagement -> DEFENDER_STRIKE, ATTACKER_STRIKEBACK both skipped
+    expect(battle.phase).toBe(BattlePhase.ATTACKER_MOVE)
+    battle.nextPhase() // -> ATTACKER_STRIKE, DEFENDER_STRIKEBACK both skipped, round increments
+    expect(battle.phase).toBe(BattlePhase.DEFENDER_MOVE)
+    expect(battle.round).toBe(1)
+  })
+
+  it("throws if a phase is exited while an engaged, unstruck creature was never given a strike", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    const centaur = battle.getDefense()[0]
+    centaur.hex = 7
+    centaur.initialHex = 7
+    battle.getOffense()[0].hex = 8
+    battle.getOffense()[0].initialHex = 8
+
+    battle.nextPhase() // -> DEFENDER_STRIKE, Centaur is now pending and never strikes
+    expect(battle.getPendingStrikes()).toEqual([centaur])
+    expect(() => battle.nextPhase()).toThrow("All eligible creatures must strike")
+  })
+
+  it("resets hasStruck for creatures on both sides whenever a strike phase is entered", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    const lion = battle.getOffense()[0]
+    const centaur = battle.getDefense()[0]
+    lion.hasStruck = true
+    centaur.hasStruck = true
+
+    battle.phaseEnterStrike()
+
+    expect(lion.hasStruck).toBe(false)
+    expect(centaur.hasStruck).toBe(false)
+  })
+
+  it("removes a creature from the battle if it is still in its entrance zone when its move phase ends", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    const centaur = battle.getDefense()[0]
+
+    expect(centaur.hex).toBe(36) // the defender's entrance zone for HexEdge.FIRST
+    battle.phaseExitMove()
+    expect(centaur.hex).toBe(0)
+  })
+
+  it("does not remove a creature that has moved onto the battle board proper", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    const centaur = battle.getDefense()[0]
+    centaur.hex = 7
+
+    battle.phaseExitMove()
+    expect(centaur.hex).toBe(7)
+  })
+
+  it("wounds creatures on drift terrain again on every strike-phase entry, not just once per round", () => {
+    // Terrain.TUNDRA's battle board has a drift hazard at battle-hex 7. phaseEnterStrike
+    // applies the drift wound unconditionally on every entry into a STRIKE-type phase,
+    // so a creature that survives both the defender's and attacker's strike phases in
+    // the same round is wounded twice.
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.TUNDRA, HexEdge.FIRST, attacking, defending)
+    const centaur = battle.getDefense()[0]
+    centaur.hex = 7
+    centaur.initialHex = 7
+
+    expect(centaur.wounds).toBe(0)
+    battle.phase = BattlePhase.DEFENDER_STRIKE
+    battle.phaseEnterStrike()
+    expect(centaur.wounds).toBe(1)
+    battle.phase = BattlePhase.ATTACKER_STRIKE
+    battle.phaseEnterStrike()
+    expect(centaur.wounds).toBe(2)
   })
 })

--- a/src/models/battle/engine.ts
+++ b/src/models/battle/engine.ts
@@ -223,6 +223,8 @@ export class Battle {
     )
   }
 
+  // TODO: rule 11.3 (a creature already in contact with an enemy may not move) is not enforced
+  // anywhere in this method or its callers - no engagement check exists in the movement-legality path.
   movementFor(creature: BattleCreature): Set<number> {
     if (creature.initialHex === 0) {
       return new Set<number>()
@@ -257,6 +259,9 @@ export class Battle {
     return this.creatures.filter(creature => creature.player !== whom.player &&
       (includeDead || creature.getRemainingHp() > 0) &&
       adjacencies.includes(creature.hex) &&
+      // TODO: only checks the cliff hazard in the fixed direction (whom -> creature), so it misses
+      // cliffs where `creature` (not `whom`) is the upper hex - creatureMovementCost above shows the
+      // correct pattern of querying both directions and ORing the result.
       this.getBoard().getEdgeHazard(whom.hex, creature.hex) !== EdgeHazard.CLIFF)
   }
 
@@ -524,6 +529,8 @@ export class Battle {
     }
   }
 
+  // TODO: rolls is never validated against the strike's expected dice count (see
+  // getAdjustedStrike/getRangestrike), so a caller can pass the wrong number of dice unnoticed.
   private performAttack(attacker: BattleCreature, defender: BattleCreature,
     rolls: number[], toHit: number, rangestrike: boolean): void {
     const totalHits = rolls.filter(roll => roll >= toHit).length


### PR DESCRIPTION
`src/models/battle/engine.ts` (573 lines) had zero test coverage for movement legality, strike resolution, and phase-transition logic, despite [`engine.test.ts`](https://github.com/aolkin/warlord/blob/main/src/models/battle/engine.test.ts) already covering rangestrike math, basic engagement, and carryover. This is prerequisite groundwork for the planned refactor of `Battle` from a class into plain state + pure functions ([`proposals/04-state-management.md`](https://github.com/aolkin/warlord/blob/main/proposals/04-state-management.md)): these tests pin down the class's current actual behavior so that refactor can be verified not to change it.

The new tests exercise the real engine code directly (no mocking), following the pattern of the existing rangestrike tests, and were derived by running each scenario against the real engine and recording its actual output - not by re-deriving the rules from the rulebook.

Several non-obvious behaviors surfaced and are now locked in by name:
- Slope and wall movement costs apply only when crossing upward; crossing back down is free regardless of native status.
- A cliff edge blocks movement in both directions, unlike walls and slopes.
- A volcano hazard blocks non-native creatures even if they can fly - unlike bog and tree, which flying bypasses.
- A flying creature can path *through* a hex occupied by another creature but can never land there.
- Drift terrain (Tundra) wounds a creature again on every strike-phase entry, not once per round, so a creature exposed through both the defender's and attacker's strike phases takes it twice.

A subsequent rulebook cross-check of the new tests found three spots where the original assertions had pinned buggy engine behavior as if it were correct. In each case the test was corrected to assert the rule-correct behavior instead, and the underlying engine gap was left as-is but flagged with a `// TODO` at its code site for future work - none of the three are fixed by this PR:
- `engagedWith`'s cliff-hazard check only queries the hazard in one fixed direction (`whom.hex` -> `creature.hex`), so it's asymmetric: the creature below a cliff correctly sees no engagement with the one above, but the reverse direction incorrectly still reports engagement. Per the Hazard Chart and rule 13.5, a cliff should block engagement symmetrically. The below-cliff assertion stays a normal test; the above-cliff direction is now an `it.fails` test documenting the correct (symmetric) behavior until the asymmetry is fixed.
- `movementFor` never enforces rule 11.3 (a creature already in contact with an enemy may not move). The flying-over-blockers test originally had both movers already in contact with an enemy at phase start, which silently relied on this missing enforcement; it's been reworked so the blocking creatures are on the movers' own side instead, so the test no longer depends on the gap.
- `performAttack` never validates the roll count passed to it against the strike's actual dice allotment. A rangestrike test was rolling 4 dice for a strength-4 Ranger, but rule 12.2 (dice = floor(power / 2)) means a strength-4 Ranger only ever rolls 2; the test now rolls 2 dice with the corresponding expected wound count.

`pnpm test`, `pnpm lint`, `pnpm typecheck`, and `pnpm build` all pass.
