### PR TITLE
Decouple Battle from masterboard and TitanGame

### DIFF
--- a/src/models/battle.ts
+++ b/src/models/battle.ts
@@ -27,3 +27,4 @@ export {
 export type { ActiveStrikeHit, IActiveStrike, RangestrikeTarget, Strike } from "./battle/strike"
 
 export { Battle } from "./battle/engine"
+export type { BattleSide } from "./battle/engine"

--- a/src/models/battle/engine.test.ts
+++ b/src/models/battle/engine.test.ts
@@ -1,28 +1,22 @@
 import { describe, expect, it } from "vitest"
 import { CreatureType } from "~/models/creature"
-import masterboard, { HexEdge, Terrain } from "~/models/masterboard"
+import { HexEdge, Terrain } from "~/models/masterboard"
 import { PlayerId } from "~/models/player"
 import { UNATTAINABLE_MOVEMENT_COST } from "./board"
 import { Battle, BattleSide } from "./engine"
 import { BattlePhase } from "./strike"
 
-// Battle-hex ids below (e.g. 1, 7, 8, 16, 20, 26, 32) are positions on the terrain's
-// battle board (see board.ts) and are unrelated to the masterboard hex ids (e.g. 1, 8,
-// 24, 1000) used to pick which terrain/battle-board a Battle is fought on.
-
-function newBattle(masterboardHex: number, edge: HexEdge, attacking: BattleSide, defending: BattleSide): Battle {
-  return new Battle(masterboard.getHex(masterboardHex).terrain, edge, attacking, defending)
+function newBattle(terrain: Terrain, edge: HexEdge, attacking: BattleSide, defending: BattleSide): Battle {
+  return new Battle(terrain, edge, attacking, defending)
 }
 
-// masterboard hex 1 is Terrain.PLAINS: no hazards, so movement/strike math below is
-// unaffected by terrain adjustments.
-const PLAINS_HEX = 1
+const PLAINS_TERRAIN = Terrain.PLAINS
 
 describe("Battle engagement", () => {
   it("starts with no engagements or pending strikes before anyone has moved", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
 
     expect(battle.phase).toBe(BattlePhase.DEFENDER_MOVE)
     expect(battle.getPendingStrikes()).toEqual([])
@@ -32,7 +26,7 @@ describe("Battle engagement", () => {
   it("moves into contact, resolves a strike, and inflicts casualties", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
     const lion = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
 
@@ -65,7 +59,7 @@ describe("Battle engagement", () => {
   it("computes to-hit purely from the skill difference on hazard-free terrain", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.OGRE] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.TROLL] }
-    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
     const ogre = battle.getOffense()[0]
     const troll = battle.getDefense()[0]
 
@@ -85,7 +79,7 @@ describe("Rangestrike targets", () => {
   } {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [attackerType] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const attacker = battle.getOffense()[0]
     const target = battle.getDefense()[0]
@@ -139,12 +133,10 @@ describe("Rangestrike targets", () => {
   })
 
   it("gives a Dragon bonus dice when rangestriking out of its native volcano hazard", () => {
-    // masterboard hex 1000 is Terrain.MOUNTAINS, whose battle board has a volcano
-    // hazard at battle-hex 15 (Dragons are volcano-native).
-    expect(masterboard.getHex(1000).terrain).toBe(Terrain.MOUNTAINS)
+    // Terrain.MOUNTAINS' battle board has a volcano hazard at battle-hex 15 (Dragons are volcano-native).
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.DRAGON] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(1000, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(Terrain.MOUNTAINS, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const dragon = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -162,13 +154,10 @@ describe("Rangestrike targets", () => {
   // the rulebook (Hazard Chart, Bramble/Rangestriking) raises the Strike-number by 1,
   // matching the melee equivalent (strikeAdjustment adds +1 toHit for the same case).
   it("raises the to-hit for a bramble-native defender rangestruck by a non-native", () => {
-    // masterboard hex 24 is Terrain.BRUSH, whose battle board has bramble hazard
-    // hexes including battle-hex 16; Gargoyles are bramble-native.
-    const brushHex = 24
-    expect(masterboard.getHex(brushHex).terrain).toBe(Terrain.BRUSH)
+    // Terrain.BRUSH's battle board has bramble hazard hexes including battle-hex 16; Gargoyles are bramble-native.
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.GARGOYLE] }
-    const battle = newBattle(brushHex, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(Terrain.BRUSH, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const gargoyle = battle.getDefense()[0]
@@ -185,10 +174,9 @@ describe("Rangestrike targets", () => {
   // A Dragon defending in a volcano is harder to hit: the strike number needed to hit
   // it is raised by one, per the in-code comment on this case.
   it("raises the to-hit for a Dragon defending in its native volcano", () => {
-    expect(masterboard.getHex(1000).terrain).toBe(Terrain.MOUNTAINS)
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.DRAGON] }
-    const battle = newBattle(1000, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(Terrain.MOUNTAINS, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const dragon = battle.getDefense()[0]
@@ -206,13 +194,10 @@ describe("Rangestrike targets", () => {
   // bramble, which - like every other hazard adjustment here - raises toHit (harder to
   // hit) rather than lowering it.
   it("raises the to-hit by one per intervening bramble hex crossed", () => {
-    // masterboard hex 5 is Terrain.JUNGLE, whose battle board has bramble hazards
-    // including battle-hexes 15 and 20, both crossed on the long-range path from
-    // battle-hex 8 to battle-hex 27.
-    expect(masterboard.getHex(5).terrain).toBe(Terrain.JUNGLE)
+    // Terrain.JUNGLE's battle board has bramble hazards at battle-hexes 15 and 20, both crossed here.
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(5, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(Terrain.JUNGLE, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -230,12 +215,10 @@ describe("Rangestrike targets", () => {
   // Crossing a wall upwards costs a skill factor, raising toHit the same way as the
   // other hazard adjustments above.
   it("raises the to-hit for a rangestrike that crosses a wall upwards", () => {
-    // masterboard hex 100 is Terrain.TOWER, whose battle board has a wall edge between
-    // battle-hexes 7 (elevation 0) and 8 (elevation 1).
-    expect(masterboard.getHex(100).terrain).toBe(Terrain.TOWER)
+    // Terrain.TOWER's battle board has a wall edge between battle-hexes 7 (elevation 0) and 8 (elevation 1).
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(100, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(Terrain.TOWER, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -260,7 +243,7 @@ describe("Carryover", () => {
   } {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR, CreatureType.CENTAUR] }
-    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const lion = battle.getOffense()[0]
     const [centaur1, centaur2] = battle.getDefense()
@@ -304,13 +287,10 @@ describe("Carryover", () => {
 
 describe("Battle board movement cost", () => {
   it("makes a bog hazard impassable for non-native, non-flying creatures but not for natives", () => {
-    // masterboard hex 8 is Terrain.MARSH, whose battle board has a bog hazard at
-    // battle-hex 8 (Trolls are bog-native, Centaurs are not).
-    const marshHex = 8
-    expect(masterboard.getHex(marshHex).terrain).toBe(Terrain.MARSH)
+    // Terrain.MARSH's battle board has a bog hazard at battle-hex 8 (Trolls are bog-native, Centaurs are not).
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.TROLL] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(marshHex, HexEdge.FIRST, attacking, defending)
+    const battle = newBattle(Terrain.MARSH, HexEdge.FIRST, attacking, defending)
     const troll = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
 

--- a/src/models/battle/engine.test.ts
+++ b/src/models/battle/engine.test.ts
@@ -1,24 +1,26 @@
 import { describe, expect, it } from "vitest"
 import { CreatureType } from "~/models/creature"
-import { TitanGame } from "~/models/game"
 import masterboard, { HexEdge, Terrain } from "~/models/masterboard"
 import { PlayerId } from "~/models/player"
-import { Random } from "~/models/random"
 import { Stack } from "~/models/stack"
 import { UNATTAINABLE_MOVEMENT_COST } from "./board"
-import { Battle } from "./engine"
+import { Battle, BattleSide } from "./engine"
 import { BattlePhase } from "./strike"
 
 // Battle-hex ids below (e.g. 1, 7, 8, 16, 20, 26, 32) are positions on the terrain's
 // battle board (see board.ts) and are unrelated to the masterboard hex ids (e.g. 1, 8,
 // 24, 1000) used to pick which terrain/battle-board a Battle is fought on.
 
-// TitanGame is only used here for its player-score lookup (irrelevant to these
-// creatures, all scored 0); the shuffle seam is still fixed for determinism.
-const noShuffleRandom: Random = { shuffle: collection => [...collection] }
+// Converts a Stack into the BattleSide shape Battle's constructor expects; all sides
+// here are scored 0, which is irrelevant to the creatures under test.
+function toBattleSide(stack: Stack): BattleSide {
+  return { player: stack.owner, score: 0, creatures: stack.creatures }
+}
 
-function newGame(): TitanGame {
-  return new TitanGame(2, noShuffleRandom)
+// Looks up the terrain for a masterboard hex and builds a Battle fought there between
+// the two given stacks - the masterboard hex id itself is otherwise unused by Battle.
+function newBattle(masterboardHex: number, edge: HexEdge, attacking: Stack, defending: Stack): Battle {
+  return new Battle(masterboard.getHex(masterboardHex).terrain, edge, toBattleSide(attacking), toBattleSide(defending))
 }
 
 // masterboard hex 1 is Terrain.PLAINS: no hazards, so movement/strike math below is
@@ -29,7 +31,7 @@ describe("Battle engagement", () => {
   it("starts with no engagements or pending strikes before anyone has moved", () => {
     const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [CreatureType.LION])
     const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.CENTAUR])
-    const battle = new Battle(PLAINS_HEX, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
 
     expect(battle.phase).toBe(BattlePhase.DEFENDER_MOVE)
     expect(battle.getPendingStrikes()).toEqual([])
@@ -39,7 +41,7 @@ describe("Battle engagement", () => {
   it("moves into contact, resolves a strike, and inflicts casualties", () => {
     const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [CreatureType.LION])
     const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.CENTAUR])
-    const battle = new Battle(PLAINS_HEX, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
     const lion = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
 
@@ -72,7 +74,7 @@ describe("Battle engagement", () => {
   it("computes to-hit purely from the skill difference on hazard-free terrain", () => {
     const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [CreatureType.OGRE])
     const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.TROLL])
-    const battle = new Battle(PLAINS_HEX, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
     const ogre = battle.getOffense()[0]
     const troll = battle.getDefense()[0]
 
@@ -92,7 +94,7 @@ describe("Rangestrike targets", () => {
   } {
     const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [attackerType])
     const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.CENTAUR])
-    const battle = new Battle(PLAINS_HEX, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const attacker = battle.getOffense()[0]
     const target = battle.getDefense()[0]
@@ -151,7 +153,7 @@ describe("Rangestrike targets", () => {
     expect(masterboard.getHex(1000).terrain).toBe(Terrain.MOUNTAINS)
     const attacking = new Stack(PlayerId.RED, 1000, 0, [CreatureType.DRAGON])
     const defending = new Stack(PlayerId.BLUE, 1000, 0, [CreatureType.CENTAUR])
-    const battle = new Battle(1000, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(1000, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const dragon = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -175,7 +177,7 @@ describe("Rangestrike targets", () => {
     expect(masterboard.getHex(brushHex).terrain).toBe(Terrain.BRUSH)
     const attacking = new Stack(PlayerId.RED, brushHex, 0, [CreatureType.RANGER])
     const defending = new Stack(PlayerId.BLUE, brushHex, 0, [CreatureType.GARGOYLE])
-    const battle = new Battle(brushHex, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(brushHex, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const gargoyle = battle.getDefense()[0]
@@ -195,7 +197,7 @@ describe("Rangestrike targets", () => {
     expect(masterboard.getHex(1000).terrain).toBe(Terrain.MOUNTAINS)
     const attacking = new Stack(PlayerId.RED, 1000, 0, [CreatureType.RANGER])
     const defending = new Stack(PlayerId.BLUE, 1000, 0, [CreatureType.DRAGON])
-    const battle = new Battle(1000, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(1000, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const dragon = battle.getDefense()[0]
@@ -219,7 +221,7 @@ describe("Rangestrike targets", () => {
     expect(masterboard.getHex(5).terrain).toBe(Terrain.JUNGLE)
     const attacking = new Stack(PlayerId.RED, 5, 0, [CreatureType.RANGER])
     const defending = new Stack(PlayerId.BLUE, 5, 0, [CreatureType.CENTAUR])
-    const battle = new Battle(5, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(5, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -242,7 +244,7 @@ describe("Rangestrike targets", () => {
     expect(masterboard.getHex(100).terrain).toBe(Terrain.TOWER)
     const attacking = new Stack(PlayerId.RED, 100, 0, [CreatureType.RANGER])
     const defending = new Stack(PlayerId.BLUE, 100, 0, [CreatureType.CENTAUR])
-    const battle = new Battle(100, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(100, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -267,7 +269,7 @@ describe("Carryover", () => {
   } {
     const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [CreatureType.LION])
     const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.CENTAUR, CreatureType.CENTAUR])
-    const battle = new Battle(PLAINS_HEX, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const lion = battle.getOffense()[0]
     const [centaur1, centaur2] = battle.getDefense()
@@ -317,7 +319,7 @@ describe("Battle board movement cost", () => {
     expect(masterboard.getHex(marshHex).terrain).toBe(Terrain.MARSH)
     const attacking = new Stack(PlayerId.RED, marshHex, 0, [CreatureType.TROLL])
     const defending = new Stack(PlayerId.BLUE, marshHex, 0, [CreatureType.CENTAUR])
-    const battle = new Battle(marshHex, HexEdge.FIRST, newGame(), attacking, defending)
+    const battle = newBattle(marshHex, HexEdge.FIRST, attacking, defending)
     const troll = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
 

--- a/src/models/battle/engine.test.ts
+++ b/src/models/battle/engine.test.ts
@@ -6,17 +6,13 @@ import { UNATTAINABLE_MOVEMENT_COST } from "./board"
 import { Battle, BattleSide } from "./engine"
 import { BattlePhase } from "./strike"
 
-function newBattle(terrain: Terrain, edge: HexEdge, attacking: BattleSide, defending: BattleSide): Battle {
-  return new Battle(terrain, edge, attacking, defending)
-}
-
 const PLAINS_TERRAIN = Terrain.PLAINS
 
 describe("Battle engagement", () => {
   it("starts with no engagements or pending strikes before anyone has moved", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
 
     expect(battle.phase).toBe(BattlePhase.DEFENDER_MOVE)
     expect(battle.getPendingStrikes()).toEqual([])
@@ -26,7 +22,7 @@ describe("Battle engagement", () => {
   it("moves into contact, resolves a strike, and inflicts casualties", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
     const lion = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
 
@@ -59,7 +55,7 @@ describe("Battle engagement", () => {
   it("computes to-hit purely from the skill difference on hazard-free terrain", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.OGRE] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.TROLL] }
-    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
     const ogre = battle.getOffense()[0]
     const troll = battle.getDefense()[0]
 
@@ -79,7 +75,7 @@ describe("Rangestrike targets", () => {
   } {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [attackerType] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const attacker = battle.getOffense()[0]
     const target = battle.getDefense()[0]
@@ -136,7 +132,7 @@ describe("Rangestrike targets", () => {
     // Terrain.MOUNTAINS' battle board has a volcano hazard at battle-hex 15 (Dragons are volcano-native).
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.DRAGON] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(Terrain.MOUNTAINS, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.MOUNTAINS, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const dragon = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -157,7 +153,7 @@ describe("Rangestrike targets", () => {
     // Terrain.BRUSH's battle board has bramble hazard hexes including battle-hex 16; Gargoyles are bramble-native.
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.GARGOYLE] }
-    const battle = newBattle(Terrain.BRUSH, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.BRUSH, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const gargoyle = battle.getDefense()[0]
@@ -176,7 +172,7 @@ describe("Rangestrike targets", () => {
   it("raises the to-hit for a Dragon defending in its native volcano", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.DRAGON] }
-    const battle = newBattle(Terrain.MOUNTAINS, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.MOUNTAINS, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const dragon = battle.getDefense()[0]
@@ -197,7 +193,7 @@ describe("Rangestrike targets", () => {
     // Terrain.JUNGLE's battle board has bramble hazards at battle-hexes 15 and 20, both crossed here.
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(Terrain.JUNGLE, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.JUNGLE, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -218,7 +214,7 @@ describe("Rangestrike targets", () => {
     // Terrain.TOWER's battle board has a wall edge between battle-hexes 7 (elevation 0) and 8 (elevation 1).
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(Terrain.TOWER, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.TOWER, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -243,7 +239,7 @@ describe("Carryover", () => {
   } {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR, CreatureType.CENTAUR] }
-    const battle = newBattle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const lion = battle.getOffense()[0]
     const [centaur1, centaur2] = battle.getDefense()
@@ -290,7 +286,7 @@ describe("Battle board movement cost", () => {
     // Terrain.MARSH's battle board has a bog hazard at battle-hex 8 (Trolls are bog-native, Centaurs are not).
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.TROLL] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = newBattle(Terrain.MARSH, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.MARSH, HexEdge.FIRST, attacking, defending)
     const troll = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
 

--- a/src/models/battle/engine.test.ts
+++ b/src/models/battle/engine.test.ts
@@ -6,13 +6,11 @@ import { UNATTAINABLE_MOVEMENT_COST } from "./board"
 import { Battle, BattleSide } from "./engine"
 import { BattlePhase } from "./strike"
 
-const PLAINS_TERRAIN = Terrain.PLAINS
-
 describe("Battle engagement", () => {
   it("starts with no engagements or pending strikes before anyone has moved", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
 
     expect(battle.phase).toBe(BattlePhase.DEFENDER_MOVE)
     expect(battle.getPendingStrikes()).toEqual([])
@@ -22,7 +20,7 @@ describe("Battle engagement", () => {
   it("moves into contact, resolves a strike, and inflicts casualties", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
     const lion = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
 
@@ -55,7 +53,7 @@ describe("Battle engagement", () => {
   it("computes to-hit purely from the skill difference on hazard-free terrain", () => {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.OGRE] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.TROLL] }
-    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
     const ogre = battle.getOffense()[0]
     const troll = battle.getDefense()[0]
 
@@ -75,7 +73,7 @@ describe("Rangestrike targets", () => {
   } {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [attackerType] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
-    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const attacker = battle.getOffense()[0]
     const target = battle.getDefense()[0]
@@ -239,7 +237,7 @@ describe("Carryover", () => {
   } {
     const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
     const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR, CreatureType.CENTAUR] }
-    const battle = new Battle(PLAINS_TERRAIN, HexEdge.FIRST, attacking, defending)
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const lion = battle.getOffense()[0]
     const [centaur1, centaur2] = battle.getDefense()

--- a/src/models/battle/engine.test.ts
+++ b/src/models/battle/engine.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest"
 import { CreatureType } from "~/models/creature"
 import masterboard, { HexEdge, Terrain } from "~/models/masterboard"
 import { PlayerId } from "~/models/player"
-import { Stack } from "~/models/stack"
 import { UNATTAINABLE_MOVEMENT_COST } from "./board"
 import { Battle, BattleSide } from "./engine"
 import { BattlePhase } from "./strike"
@@ -11,16 +10,8 @@ import { BattlePhase } from "./strike"
 // battle board (see board.ts) and are unrelated to the masterboard hex ids (e.g. 1, 8,
 // 24, 1000) used to pick which terrain/battle-board a Battle is fought on.
 
-// Converts a Stack into the BattleSide shape Battle's constructor expects; all sides
-// here are scored 0, which is irrelevant to the creatures under test.
-function toBattleSide(stack: Stack): BattleSide {
-  return { player: stack.owner, score: 0, creatures: stack.creatures }
-}
-
-// Looks up the terrain for a masterboard hex and builds a Battle fought there between
-// the two given stacks - the masterboard hex id itself is otherwise unused by Battle.
-function newBattle(masterboardHex: number, edge: HexEdge, attacking: Stack, defending: Stack): Battle {
-  return new Battle(masterboard.getHex(masterboardHex).terrain, edge, toBattleSide(attacking), toBattleSide(defending))
+function newBattle(masterboardHex: number, edge: HexEdge, attacking: BattleSide, defending: BattleSide): Battle {
+  return new Battle(masterboard.getHex(masterboardHex).terrain, edge, attacking, defending)
 }
 
 // masterboard hex 1 is Terrain.PLAINS: no hazards, so movement/strike math below is
@@ -29,8 +20,8 @@ const PLAINS_HEX = 1
 
 describe("Battle engagement", () => {
   it("starts with no engagements or pending strikes before anyone has moved", () => {
-    const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [CreatureType.LION])
-    const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.CENTAUR])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
     const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
 
     expect(battle.phase).toBe(BattlePhase.DEFENDER_MOVE)
@@ -39,8 +30,8 @@ describe("Battle engagement", () => {
   })
 
   it("moves into contact, resolves a strike, and inflicts casualties", () => {
-    const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [CreatureType.LION])
-    const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.CENTAUR])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
     const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
     const lion = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]
@@ -72,8 +63,8 @@ describe("Battle engagement", () => {
   })
 
   it("computes to-hit purely from the skill difference on hazard-free terrain", () => {
-    const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [CreatureType.OGRE])
-    const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.TROLL])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.OGRE] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.TROLL] }
     const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
     const ogre = battle.getOffense()[0]
     const troll = battle.getDefense()[0]
@@ -92,8 +83,8 @@ describe("Rangestrike targets", () => {
     attacker: ReturnType<Battle["getOffense"]>[number]
     target: ReturnType<Battle["getDefense"]>[number]
   } {
-    const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [attackerType])
-    const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.CENTAUR])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [attackerType] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
     const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const attacker = battle.getOffense()[0]
@@ -151,8 +142,8 @@ describe("Rangestrike targets", () => {
     // masterboard hex 1000 is Terrain.MOUNTAINS, whose battle board has a volcano
     // hazard at battle-hex 15 (Dragons are volcano-native).
     expect(masterboard.getHex(1000).terrain).toBe(Terrain.MOUNTAINS)
-    const attacking = new Stack(PlayerId.RED, 1000, 0, [CreatureType.DRAGON])
-    const defending = new Stack(PlayerId.BLUE, 1000, 0, [CreatureType.CENTAUR])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.DRAGON] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
     const battle = newBattle(1000, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const dragon = battle.getOffense()[0]
@@ -175,8 +166,8 @@ describe("Rangestrike targets", () => {
     // hexes including battle-hex 16; Gargoyles are bramble-native.
     const brushHex = 24
     expect(masterboard.getHex(brushHex).terrain).toBe(Terrain.BRUSH)
-    const attacking = new Stack(PlayerId.RED, brushHex, 0, [CreatureType.RANGER])
-    const defending = new Stack(PlayerId.BLUE, brushHex, 0, [CreatureType.GARGOYLE])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.GARGOYLE] }
     const battle = newBattle(brushHex, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
@@ -195,8 +186,8 @@ describe("Rangestrike targets", () => {
   // it is raised by one, per the in-code comment on this case.
   it("raises the to-hit for a Dragon defending in its native volcano", () => {
     expect(masterboard.getHex(1000).terrain).toBe(Terrain.MOUNTAINS)
-    const attacking = new Stack(PlayerId.RED, 1000, 0, [CreatureType.RANGER])
-    const defending = new Stack(PlayerId.BLUE, 1000, 0, [CreatureType.DRAGON])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.DRAGON] }
     const battle = newBattle(1000, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
@@ -219,8 +210,8 @@ describe("Rangestrike targets", () => {
     // including battle-hexes 15 and 20, both crossed on the long-range path from
     // battle-hex 8 to battle-hex 27.
     expect(masterboard.getHex(5).terrain).toBe(Terrain.JUNGLE)
-    const attacking = new Stack(PlayerId.RED, 5, 0, [CreatureType.RANGER])
-    const defending = new Stack(PlayerId.BLUE, 5, 0, [CreatureType.CENTAUR])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
     const battle = newBattle(5, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
@@ -242,8 +233,8 @@ describe("Rangestrike targets", () => {
     // masterboard hex 100 is Terrain.TOWER, whose battle board has a wall edge between
     // battle-hexes 7 (elevation 0) and 8 (elevation 1).
     expect(masterboard.getHex(100).terrain).toBe(Terrain.TOWER)
-    const attacking = new Stack(PlayerId.RED, 100, 0, [CreatureType.RANGER])
-    const defending = new Stack(PlayerId.BLUE, 100, 0, [CreatureType.CENTAUR])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.RANGER] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
     const battle = newBattle(100, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const ranger = battle.getOffense()[0]
@@ -267,8 +258,8 @@ describe("Carryover", () => {
     centaur1: ReturnType<Battle["getDefense"]>[number]
     centaur2: ReturnType<Battle["getDefense"]>[number]
   } {
-    const attacking = new Stack(PlayerId.RED, PLAINS_HEX, 0, [CreatureType.LION])
-    const defending = new Stack(PlayerId.BLUE, PLAINS_HEX, 0, [CreatureType.CENTAUR, CreatureType.CENTAUR])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR, CreatureType.CENTAUR] }
     const battle = newBattle(PLAINS_HEX, HexEdge.FIRST, attacking, defending)
     battle.phase = BattlePhase.ATTACKER_STRIKE
     const lion = battle.getOffense()[0]
@@ -317,8 +308,8 @@ describe("Battle board movement cost", () => {
     // battle-hex 8 (Trolls are bog-native, Centaurs are not).
     const marshHex = 8
     expect(masterboard.getHex(marshHex).terrain).toBe(Terrain.MARSH)
-    const attacking = new Stack(PlayerId.RED, marshHex, 0, [CreatureType.TROLL])
-    const defending = new Stack(PlayerId.BLUE, marshHex, 0, [CreatureType.CENTAUR])
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.TROLL] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
     const battle = newBattle(marshHex, HexEdge.FIRST, attacking, defending)
     const troll = battle.getOffense()[0]
     const centaur = battle.getDefense()[0]

--- a/src/models/battle/engine.ts
+++ b/src/models/battle/engine.ts
@@ -2,10 +2,8 @@ import { memoize } from "lodash-es"
 import { assert } from "~/utils/assert"
 import { div } from "~/utils/math"
 import { CREATURE_DATA, CreatureType } from "../creature"
-import { TitanGame } from "../game"
-import masterboard, { HexEdge, Terrain } from "../masterboard"
+import { HexEdge, Terrain } from "../masterboard"
 import { PlayerId } from "../player"
-import { Stack } from "../stack"
 import {
   BATTLE_BOARD_ADJACENCIES,
   BATTLE_BOARDS,
@@ -30,8 +28,16 @@ import {
   isRangestrike
 } from "./strike"
 
+// What a Battle needs to know about one of its two participants - deliberately not the full
+// Stack, since a Battle has no other use for a Stack's masterboard position, marker, splits,
+// or muster state.
+export interface BattleSide {
+  player: PlayerId
+  score: number
+  creatures: CreatureType[]
+}
+
 export class Battle {
-  readonly hex: number
   readonly attackerEdge: HexEdge
   readonly terrain: Terrain
   readonly attacker: PlayerId
@@ -42,43 +48,34 @@ export class Battle {
   phase: BattlePhase
   activeStrike?: ActiveStrike
 
-  // Parameters optional for Hydration
-  constructor(hex: number, edge: HexEdge, game: TitanGame, attacking?: Stack, defending?: Stack) {
+  constructor(terrain: Terrain, edge: HexEdge, attacking: BattleSide, defending: BattleSide) {
     this.creatureOnHex = memoize(this.creatureOnHex)
     this.round = 0
     this.phase = BattlePhase.DEFENDER_MOVE
-    this.hex = hex
-    this.terrain = masterboard.getHex(hex).terrain
-    this.attackerEdge = this.terrain === Terrain.TOWER ? HexEdge.SECOND : edge
-    if (attacking !== undefined && defending !== undefined) {
-      this.attacker = attacking.owner
-      this.defender = defending.owner
-      this.creatures = attacking.creatures.map(type => new BattleCreature({
-        type,
-        player: attacking.owner,
-        playerScore: game.getPlayerById()(attacking.owner)?.score ?? 0,
-        hex: 37 + this.attackerEdge * 2
-      })).concat(defending.creatures.map(type => new BattleCreature({
-        type,
-        player: defending.owner,
-        playerScore: game.getPlayerById()(defending.owner)?.score ?? 0,
-        hex: 36 + this.attackerEdge * 2
-      })))
-    } else {
-      // These will be overwritten during hydration, but satisfy TypeScript
-      this.attacker = 0
-      this.defender = 0
-      this.creatures = []
-    }
+    this.terrain = terrain
+    this.attackerEdge = terrain === Terrain.TOWER ? HexEdge.SECOND : edge
+    this.attacker = attacking.player
+    this.defender = defending.player
+    this.creatures = attacking.creatures.map(type => new BattleCreature({
+      type,
+      player: attacking.player,
+      playerScore: attacking.score,
+      hex: 37 + this.attackerEdge * 2
+    })).concat(defending.creatures.map(type => new BattleCreature({
+      type,
+      player: defending.player,
+      playerScore: defending.score,
+      hex: 36 + this.attackerEdge * 2
+    })))
   }
 
-  static hydrate(battle: Battle, game: TitanGame): Battle {
-    const hydrated = new Battle(battle.hex, battle.attackerEdge, game)
-    Object.assign(hydrated, {
+  static hydrate(battle: Battle): Battle {
+    const hydrated: Battle = Object.assign(Object.create(Battle.prototype) as Battle, {
       ...battle,
       creatures: battle.creatures.map(creature => new BattleCreature(creature)),
       activeStrike: battle.activeStrike === undefined ? undefined : new ActiveStrike(battle.activeStrike)
     })
+    hydrated.creatureOnHex = memoize(hydrated.creatureOnHex)
     return hydrated
   }
 

--- a/src/models/battle/engine.ts
+++ b/src/models/battle/engine.ts
@@ -28,9 +28,6 @@ import {
   isRangestrike
 } from "./strike"
 
-// What a Battle needs to know about one of its two participants - deliberately not the full
-// Stack, since a Battle has no other use for a Stack's masterboard position, marker, splits,
-// or muster state.
 export interface BattleSide {
   player: PlayerId
   score: number

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -79,6 +79,7 @@ export class TitanGame {
   activePlayer: number
   activePhase: MasterboardPhase
   activeBattle?: Battle
+  activeBattleHex?: number
 
   constructor(numPlayers: number, random: Random = defaultRandom) {
     this.round = 0
@@ -86,6 +87,7 @@ export class TitanGame {
     this.activePlayer = 0
     this.activeRoll = undefined
     this.activeBattle = undefined
+    this.activeBattleHex = undefined
     this.activePhase = MasterboardPhase.SPLIT
     const colors = random.shuffle(range(0, 5))
     this.players = range(0, numPlayers).map(i => new Player(colors[i], `Player ${i + 1}`))

--- a/src/models/game/battle.ts
+++ b/src/models/game/battle.ts
@@ -13,6 +13,10 @@ interface IStrikePayload { attacker: BattleCreature, rolls: number[] }
 interface AttackPayload extends IStrikePayload { target: BattleCreature, optionalToHit?: number }
 interface RangestrikePayload extends IStrikePayload { target: RangestrikeTarget }
 
+function toBattleSide(stack: Stack, score: number): BattleSide {
+  return { player: stack.owner, score, creatures: stack.creatures }
+}
+
 export interface GameBattle {
   getBattleActivePlayer(): PlayerId | undefined
   getBattlePhaseType(): BattlePhaseType | undefined
@@ -70,16 +74,8 @@ export const gameBattle: GameBattle & ThisType<TitanGame> = {
   mInitiateBattle({ attacking, defending }: BattlePayload): void {
     assert(attacking.attackEdge !== undefined, "Cannot attack without coming from somewhere")
     const terrain = masterboard.getHex(attacking.hex).terrain
-    const attackingSide: BattleSide = {
-      player: attacking.owner,
-      score: this.getPlayerById()(attacking.owner)?.score ?? 0,
-      creatures: attacking.creatures
-    }
-    const defendingSide: BattleSide = {
-      player: defending.owner,
-      score: this.getPlayerById()(defending.owner)?.score ?? 0,
-      creatures: defending.creatures
-    }
+    const attackingSide = toBattleSide(attacking, this.getPlayerById()(attacking.owner)?.score ?? 0)
+    const defendingSide = toBattleSide(defending, this.getPlayerById()(defending.owner)?.score ?? 0)
     this.activeBattle = new Battle(terrain, attacking.attackEdge, attackingSide, defendingSide)
     this.activeBattleHex = attacking.hex
   },

--- a/src/models/game/battle.ts
+++ b/src/models/game/battle.ts
@@ -1,7 +1,8 @@
 import { matches } from "lodash-es"
 import { View } from "~/store/ui/selection"
 import { assert } from "~/utils/assert"
-import { Battle, BATTLE_PHASE_TYPES, BattleCreature, BattlePhaseType, RangestrikeTarget } from "../battle"
+import { Battle, BATTLE_PHASE_TYPES, BattleCreature, BattlePhaseType, BattleSide, RangestrikeTarget } from "../battle"
+import masterboard from "../masterboard"
 import { PlayerId } from "../player"
 import { Stack } from "../stack"
 import type { ActionContext, TitanGame } from "../game"
@@ -68,7 +69,19 @@ export const gameBattle: GameBattle & ThisType<TitanGame> = {
 
   mInitiateBattle({ attacking, defending }: BattlePayload): void {
     assert(attacking.attackEdge !== undefined, "Cannot attack without coming from somewhere")
-    this.activeBattle = new Battle(attacking.hex, attacking.attackEdge, this, attacking, defending)
+    const terrain = masterboard.getHex(attacking.hex).terrain
+    const attackingSide: BattleSide = {
+      player: attacking.owner,
+      score: this.getPlayerById()(attacking.owner)?.score ?? 0,
+      creatures: attacking.creatures
+    }
+    const defendingSide: BattleSide = {
+      player: defending.owner,
+      score: this.getPlayerById()(defending.owner)?.score ?? 0,
+      creatures: defending.creatures
+    }
+    this.activeBattle = new Battle(terrain, attacking.attackEdge, attackingSide, defendingSide)
+    this.activeBattleHex = attacking.hex
   },
 
   mNextBattlePhase(): void {

--- a/src/models/game/persistence.ts
+++ b/src/models/game/persistence.ts
@@ -34,7 +34,7 @@ export const gamePersistence: GamePersistence & ThisType<TitanGame> = {
         assign(new Player(player.id, player.name), player)),
       stacks: hydration.stacks.map((stack: Stack) =>
         assign(new Stack(stack.owner, stack.hex, stack.marker, stack.creatures), stack)),
-      activeBattle: hydration.activeBattle !== undefined ? Battle.hydrate(hydration.activeBattle, this) : undefined
+      activeBattle: hydration.activeBattle !== undefined ? Battle.hydrate(hydration.activeBattle) : undefined
     })
   },
 


### PR DESCRIPTION
`Battle` previously took a masterboard `hex` and only ever used it to look up `terrain` at construction, and took a full `TitanGame` only to snapshot each side's score at construction. Neither `hex` nor `game` was used anywhere else in the class. This decouples `Battle` from both so it can be constructed from plain data: the constructor now takes `terrain: Terrain` directly and a `BattleSide` (`{ player, score, creatures }`) for each side, and both sides are required rather than optional.

The masterboard hex a battle is occurring on moves to a new sibling field, `TitanGame.activeBattleHex`, since it describes the battle's masterboard position rather than anything intrinsic to the battle. [`Battle.hydrate`](https://github.com/aolkin/warlord/blob/refactor/decouple-battle-board/src/models/battle/engine.ts) no longer routes through the public constructor with dummy args - it reconstructs via `Object.create(Battle.prototype)` + `Object.assign`.

The open PR #71 (battle engine characterization tests) will be rebased onto this afterward, with its tests rewritten against this cleaner constructor.