### PR TITLE
Remove Object.prototype.guid extension and add explicit id fields

### DIFF
--- a/src/components/game/battle/ActiveStrikePanel.vue
+++ b/src/components/game/battle/ActiveStrikePanel.vue
@@ -27,7 +27,7 @@
       </v-card-item>
       <v-card-item
         v-for="([creature, hits], index) in targets"
-        :key="creature.guid"
+        :key="creature.id"
       >
         {{ index === 0 ? "Dealt" : "Carried over" }} {{ hitsString(hits) }} to a
         {{ creature.name() }}{{ activeStrike?.rangestrike ? " with a rangestrike" : "" }}.

--- a/src/components/game/battle/PendingCreatures.vue
+++ b/src/components/game/battle/PendingCreatures.vue
@@ -2,7 +2,7 @@
   <div class="px-2 pb-1">
     <Creature
       v-for="creature in creatures"
-      :key="creature.guid"
+      :key="creature.id"
       :type="creature.type"
       :player="playerById(creature.player)"
       :class="{ interactive: activeBattle.phase === expectedPhase,

--- a/src/components/game/masterboard/Masterboard.vue
+++ b/src/components/game/masterboard/Masterboard.vue
@@ -35,7 +35,7 @@
       >
         <MasterboardStack
           v-for="stack in sortedStacks"
-          :key="stack.guid"
+          :key="stack.id"
           :stack="stack"
         />
       </g>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,8 @@
-import { random } from "lodash-es"
 import { createApp } from "vue"
 import App from "~/App.vue"
 import vuetify from "~/plugins/vuetify"
 import vuex from "~/plugins/vuex"
 import { loadFonts } from "~/plugins/webfontloader"
-
-(() => {
-  let idCounter = random(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
-  Object.defineProperty(Object.prototype, "__guid", {
-    writable: true
-  })
-  Object.defineProperty(Object.prototype, "guid", {
-    get: function() {
-      if (this.__guid === undefined) {
-        this.__guid = idCounter++
-      }
-      return this.__guid
-    }
-  })
-})()
 
 void loadFonts()
 

--- a/src/models/battle/combatant.ts
+++ b/src/models/battle/combatant.ts
@@ -8,6 +8,7 @@ export interface IBattleCreature {
   readonly player: PlayerId
   readonly playerScore: number
   hex: number
+  id?: number
   wounds?: number
   initialHex?: number
   hasStruck?: boolean
@@ -27,7 +28,7 @@ export class BattleCreature {
   constructor(props: IBattleCreature) {
     Object.assign(this, {
       ...props,
-      id: battleCreatureIdCounter++,
+      id: props.id ?? battleCreatureIdCounter++,
       wounds: props.wounds ?? 0,
       initialHex: props.initialHex ?? props.hex,
       hasStruck: props.hasStruck ?? false

--- a/src/models/battle/combatant.ts
+++ b/src/models/battle/combatant.ts
@@ -1,6 +1,8 @@
 import { CREATURE_DATA, CreatureType } from "../creature"
 import { PlayerId } from "../player"
 
+let battleCreatureIdCounter = 0
+
 export interface IBattleCreature {
   readonly type: CreatureType
   readonly player: PlayerId
@@ -15,6 +17,7 @@ export interface IBattleCreature {
 // which are actually assigned at runtime via Object.assign in the constructor below.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface BattleCreature extends IBattleCreature {
+  readonly id: number
   wounds: number
   initialHex: number
   hasStruck: boolean
@@ -24,6 +27,7 @@ export class BattleCreature {
   constructor(props: IBattleCreature) {
     Object.assign(this, {
       ...props,
+      id: battleCreatureIdCounter++,
       wounds: props.wounds ?? 0,
       initialHex: props.initialHex ?? props.hex,
       hasStruck: props.hasStruck ?? false

--- a/src/models/battle/engine.test.ts
+++ b/src/models/battle/engine.test.ts
@@ -619,3 +619,16 @@ describe("Battle phase transitions", () => {
     expect(centaur.wounds).toBe(2)
   })
 })
+
+describe("Battle hydration", () => {
+  it("preserves creature ids across a persist/restore round trip", () => {
+    const attacking: BattleSide = { player: PlayerId.RED, score: 0, creatures: [CreatureType.LION] }
+    const defending: BattleSide = { player: PlayerId.BLUE, score: 0, creatures: [CreatureType.CENTAUR] }
+    const battle = new Battle(Terrain.PLAINS, HexEdge.FIRST, attacking, defending)
+    const idsBeforeHydration = battle.creatures.map(creature => creature.id)
+
+    const hydrated = Battle.hydrate(JSON.parse(JSON.stringify(battle)) as Battle)
+
+    expect(hydrated.creatures.map(creature => creature.id)).toEqual(idsBeforeHydration)
+  })
+})

--- a/src/models/stack.ts
+++ b/src/models/stack.ts
@@ -4,6 +4,8 @@ import { CREATURE_DATA, CreatureType, MUSTER_DATA } from "./creature"
 import { HexEdge, Terrain } from "./masterboard"
 import { PlayerId } from "./player"
 
+let stackIdCounter = 0
+
 export type StackRef = number
 
 export type MusterBasis = [CreatureType, number]
@@ -18,6 +20,7 @@ export class Stack {
   readonly marker: number
   readonly split: boolean[]
   readonly recruits: Record<number, MusterChoice>
+  readonly id: number
 
   origin: number
   hex: number
@@ -35,6 +38,7 @@ export class Stack {
     this.origin = start
     this.marker = marker
     this.recruits = {}
+    this.id = stackIdCounter++
   }
 
   numSplitting(): number {

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,13 +1,6 @@
 declare module "*.css"
 declare module "vuetify/styles"
 
-// src/main.ts patches every object with a lazily-assigned unique id, used as
-// a stable v-for :key for model instances that don't carry their own id.
-interface Object {
-  __guid?: number
-  guid: number
-}
-
 declare module "assert" {
   function assert(value: unknown, message?: string | Error): asserts value
   export = assert


### PR DESCRIPTION
Replaces lazy-assigned guid on every object with explicit id fields on BattleCreature and Stack classes. This eliminates prototype pollution and makes object identity explicit at construction time rather than relying on runtime property assignment.

Removes the unused app.config.unwrapInjectedRef = true setting (confirmed no inject() usage in codebase).