### PR TITLE
Split BattleCreature into plain state and pure rule functions

### DIFF
--- a/src/components/game/battle/ActiveStrikePanel.vue
+++ b/src/components/game/battle/ActiveStrikePanel.vue
@@ -30,8 +30,8 @@
         :key="creature.id"
       >
         {{ index === 0 ? "Dealt" : "Carried over" }} {{ hitsString(hits) }} to a
-        {{ creature.name() }}{{ activeStrike?.rangestrike ? " with a rangestrike" : "" }}.
-        <span v-if="creature.getRemainingHp() < 1">The {{ creature.name() }} is dead.</span>
+        {{ creatureName(creature) }}{{ activeStrike?.rangestrike ? " with a rangestrike" : "" }}.
+        <span v-if="getRemainingHp(creature) < 1">The {{ creatureName(creature) }} is dead.</span>
       </v-card-item>
       <v-card-text v-if="activeStrike">
         <span v-if="activeStrike?.canCarryover && battleCarryoverTargets">
@@ -63,14 +63,16 @@
 <script lang="ts">
 import { defineComponent } from "vue"
 import { mapActions, mapGetters, mapState } from "vuex"
-import { ActiveStrike, BattleCreature, Hazard, Strike } from "~/models/battle"
+import { ActiveStrike, BattleCreature, creatureName, getRemainingHp, Hazard, Strike } from "~/models/battle"
 import StrikePanelTitle from "./StrikePanelTitle.vue"
 
 export default defineComponent({
   name: "ActiveStrikePanel",
   components: { StrikePanelTitle },
   data: () => ({
-    Hazard
+    Hazard,
+    creatureName,
+    getRemainingHp
   }),
   computed: {
     ...mapState("game", ["activeBattle"]),

--- a/src/components/game/battle/RangestrikeConfirmation.vue
+++ b/src/components/game/battle/RangestrikeConfirmation.vue
@@ -43,7 +43,7 @@
 import { computed } from "vue"
 import { isEqual } from "lodash-es"
 import { useStore } from "vuex"
-import { BattleCreature, RangestrikeTarget, Strike } from "~/models/battle"
+import { BattleCreature, creatureName, RangestrikeTarget, Strike } from "~/models/battle"
 import { useSelectionStore } from "~/stores/ui/selection"
 import { div } from "~/utils/math"
 
@@ -60,9 +60,10 @@ const store = useStore()
 const selectionStore = useSelectionStore()
 
 const activeBattle = computed(() => store.state.game.activeBattle)
-const selectedCreatureName = computed(() => selectionStore.selectedCreature?.name() ?? "")
+const selectedCreatureName = computed(() =>
+  selectionStore.selectedCreature ? creatureName(selectionStore.selectedCreature) : "")
 const targetedCreature = computed<BattleCreature>(() => props.target.creature)
-const targetedCreatureName = computed(() => targetedCreature.value?.name() ?? "")
+const targetedCreatureName = computed(() => targetedCreature.value ? creatureName(targetedCreature.value) : "")
 const targetedStrike = computed<Strike>(() =>
   activeBattle.value.getTargetedStrike(selectionStore.selectedCreature, props.target))
 const targetedStrikeUnadjusted = computed<Strike>(() => {

--- a/src/components/game/battle/StrikeConfirmation.vue
+++ b/src/components/game/battle/StrikeConfirmation.vue
@@ -29,7 +29,7 @@
             :prepend-icon="`mdi-dice-${targetedStrike.toHit}`"
             :value="targetedStrike.toHit"
           >
-            {{ normalCarryovers.map(creature => creature.name()).join(", ") }}
+            {{ normalCarryovers.map(creature => creatureName(creature)).join(", ") }}
           </v-list-item>
           <v-list-item
             v-for="(creatures, toHit) in toHitAdjustments"
@@ -37,7 +37,7 @@
             :prepend-icon="`mdi-dice-${toHit}`"
             :value="Number(toHit)"
           >
-            {{ [...normalCarryovers, ...creatures].map(creature => creature.name()).join(", ") }}
+            {{ [...normalCarryovers, ...creatures].map(creature => creatureName(creature)).join(", ") }}
           </v-list-item>
         </v-list>
       </v-card-text>
@@ -65,7 +65,7 @@
 import { computed } from "vue"
 import { isEqual, range } from "lodash-es"
 import { useStore } from "vuex"
-import { BattleCreature, isRangestrike, Strike } from "~/models/battle"
+import { BattleCreature, creatureName, getRemainingHp, isRangestrike, Strike } from "~/models/battle"
 import { useSelectionStore } from "~/stores/ui/selection"
 
 const props = defineProps<{
@@ -83,8 +83,10 @@ const store = useStore()
 const selectionStore = useSelectionStore()
 
 const activeBattle = computed(() => store.state.game.activeBattle)
-const selectedCreatureName = computed(() => selectionStore.selectedCreature?.name() ?? "")
-const targetedCreatureName = computed(() => props.targetedCreature?.name() ?? "")
+const selectedCreatureName = computed(() =>
+  selectionStore.selectedCreature ? creatureName(selectionStore.selectedCreature) : "")
+const targetedCreatureName = computed(() =>
+  props.targetedCreature ? creatureName(props.targetedCreature) : "")
 const targetedStrike = computed<Strike>(() =>
   activeBattle.value.getTargetedStrike(selectionStore.selectedCreature, props.targetedCreature))
 const targetedStrikeUnadjusted = computed<Strike>(() =>
@@ -93,7 +95,7 @@ const targetedStrikeUnadjusted = computed<Strike>(() =>
 const targetedStrikeWasAdjusted = computed(() =>
   !isEqual(targetedStrikeUnadjusted.value, targetedStrike.value))
 const carryoversImpossible = computed(() => selectionStore.engagements.length < 2 ||
-  targetedStrike.value.dice - props.targetedCreature.getRemainingHp() <= 0)
+  targetedStrike.value.dice - getRemainingHp(props.targetedCreature) <= 0)
 const normalCarryovers = computed<BattleCreature[]>(() => carryoversImpossible.value
   ? []
   : selectionStore.engagements

--- a/src/components/game/battle/StrikePanelTitle.vue
+++ b/src/components/game/battle/StrikePanelTitle.vue
@@ -1,35 +1,36 @@
 <template>
   <v-card-title>
     <span :class="`text-player-${attacker.player}`">
-      {{ attacker.name() }}
+      {{ creatureName(attacker) }}
       <span v-if="attackerHazard !== Hazard.NONE">({{ Hazard[attackerHazard].toLowerCase() }}) </span>
     </span>
     <span>vs </span>
     <span :class="`text-player-${target.player}`">
-      {{ target.name() }}
+      {{ creatureName(target) }}
       <span v-if="targetHazard !== Hazard.NONE">({{ Hazard[targetHazard].toLowerCase() }})</span>
     </span>
   </v-card-title>
 </template>
 <script lang="ts">
-import { defineComponent } from "vue"
+import { defineComponent, PropType } from "vue"
 import { mapState } from "vuex"
-import { BattleBoard, BattleCreature, Hazard } from "~/models/battle"
+import { BattleBoard, BattleCreature, creatureName, Hazard } from "~/models/battle"
 
 export default defineComponent({
   name: "StrikePanelTitle",
   props: {
     attacker: {
-      type: BattleCreature,
+      type: Object as PropType<BattleCreature>,
       required: true
     },
     target: {
-      type: BattleCreature,
+      type: Object as PropType<BattleCreature>,
       required: true
     }
   },
   data: () => ({
-    Hazard
+    Hazard,
+    creatureName
   }),
   computed: {
     ...mapState("game", ["activeBattle"]),

--- a/src/models/battle.ts
+++ b/src/models/battle.ts
@@ -12,8 +12,19 @@ export {
 } from "./battle/board"
 export type { BattleBoardProps } from "./battle/board"
 
-export { BattleCreature } from "./battle/combatant"
-export type { IBattleCreature } from "./battle/combatant"
+export {
+  createBattleCreature,
+  creatureName,
+  getRemainingHp,
+  getStrength,
+  performStrike,
+  phaseEnterMove,
+  phaseEnterStrike,
+  phaseExitMove,
+  phaseExitStrikeback,
+  wound
+} from "./battle/combatant"
+export type { BattleCreature, BattleCreatureInit } from "./battle/combatant"
 
 export {
   ActiveStrike,

--- a/src/models/battle/combatant.ts
+++ b/src/models/battle/combatant.ts
@@ -3,7 +3,7 @@ import { PlayerId } from "../player"
 
 let battleCreatureIdCounter = 0
 
-export interface IBattleCreature {
+export interface BattleCreatureInit {
   readonly type: CreatureType
   readonly player: PlayerId
   readonly playerScore: number
@@ -14,64 +14,63 @@ export interface IBattleCreature {
   hasStruck?: boolean
 }
 
-// The interface/class pair is merged so the class type picks up these members,
-// which are actually assigned at runtime via Object.assign in the constructor below.
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface BattleCreature extends IBattleCreature {
+export interface BattleCreature {
+  readonly type: CreatureType
+  readonly player: PlayerId
+  readonly playerScore: number
   readonly id: number
+  hex: number
   wounds: number
   initialHex: number
   hasStruck: boolean
 }
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class BattleCreature {
-  constructor(props: IBattleCreature) {
-    Object.assign(this, {
-      ...props,
-      id: props.id ?? battleCreatureIdCounter++,
-      wounds: props.wounds ?? 0,
-      initialHex: props.initialHex ?? props.hex,
-      hasStruck: props.hasStruck ?? false
-    })
-  }
 
-  name(): string {
-    return CREATURE_DATA[this.type].name
+export function createBattleCreature(props: BattleCreatureInit): BattleCreature {
+  return {
+    ...props,
+    id: props.id ?? battleCreatureIdCounter++,
+    wounds: props.wounds ?? 0,
+    initialHex: props.initialHex ?? props.hex,
+    hasStruck: props.hasStruck ?? false
   }
+}
 
-  getStrength(): number {
-    return CREATURE_DATA[this.type].getStrength(this.playerScore)
+export function creatureName(creature: BattleCreature): string {
+  return CREATURE_DATA[creature.type].name
+}
+
+export function getStrength(creature: BattleCreature): number {
+  return CREATURE_DATA[creature.type].getStrength(creature.playerScore)
+}
+
+export function getRemainingHp(creature: BattleCreature): number {
+  return getStrength(creature) - creature.wounds
+}
+
+export function wound(creature: BattleCreature, amount: number): void {
+  creature.wounds += amount
+}
+
+export function performStrike(creature: BattleCreature): void {
+  creature.hasStruck = true
+}
+
+export function phaseEnterMove(creature: BattleCreature): void {
+  creature.initialHex = creature.hex
+}
+
+export function phaseExitMove(creature: BattleCreature): void {
+  if (creature.hex >= 36) {
+    creature.hex = 0
   }
+}
 
-  getRemainingHp(): number {
-    return this.getStrength() - this.wounds
-  }
+export function phaseEnterStrike(creature: BattleCreature): void {
+  creature.hasStruck = false
+}
 
-  wound(amount: number): void {
-    this.wounds += amount
-  }
-
-  performStrike(): void {
-    this.hasStruck = true
-  }
-
-  phaseEnterMove(): void {
-    this.initialHex = this.hex
-  }
-
-  phaseExitMove(): void {
-    if (this.hex >= 36) {
-      this.hex = 0
-    }
-  }
-
-  phaseEnterStrike(): void {
-    this.hasStruck = false
-  }
-
-  phaseExitStrikeback(): void {
-    if (this.getRemainingHp() <= 0) {
-      this.hex = 0
-    }
+export function phaseExitStrikeback(creature: BattleCreature): void {
+  if (getRemainingHp(creature) <= 0) {
+    creature.hex = 0
   }
 }

--- a/src/models/battle/engine.test.ts
+++ b/src/models/battle/engine.test.ts
@@ -3,7 +3,7 @@ import { CREATURE_DATA, CreatureType } from "~/models/creature"
 import { HexEdge, Terrain } from "~/models/masterboard"
 import { PlayerId } from "~/models/player"
 import { UNATTAINABLE_MOVEMENT_COST } from "./board"
-import { BattleCreature } from "./combatant"
+import { BattleCreature, getRemainingHp, performStrike } from "./combatant"
 import { Battle, BattleSide } from "./engine"
 import { BattlePhase } from "./strike"
 
@@ -51,7 +51,7 @@ describe("Battle engagement", () => {
 
     expect(lion.hasStruck).toBe(true)
     expect(centaur.wounds).toBe(3) // Centaur's full strength (3); capped, not overkill
-    expect(centaur.getRemainingHp()).toBe(0)
+    expect(getRemainingHp(centaur)).toBe(0)
     expect(centaur.hex).toBe(7) // corpses stay on the board until phaseExitStrikeback
   })
 })
@@ -247,7 +247,7 @@ describe("Carryover", () => {
     const { battle, lion, centaur1, centaur2 } = setupTripleEngagement()
 
     battle.strike(lion, centaur1, [6, 6, 6, 6, 6])
-    expect(centaur1.getRemainingHp()).toBe(0)
+    expect(getRemainingHp(centaur1)).toBe(0)
     expect(battle.activeStrike?.canCarryover).toBe(true)
     // getCarryoverHits = 5 total hits - 3 assigned to centaur1
     expect(battle.activeStrike?.getCarryoverHits()).toBe(2)
@@ -466,7 +466,7 @@ describe("Engagement edge cases", () => {
     place(excluded, 8) // toHit 6, raised by the wall - harder than the rolled toHit
 
     battle.strike(lion, primary, [6, 6, 6, 6, 6])
-    expect(primary.getRemainingHp()).toBe(0) // overkilled, so it drops out of engagedWith too
+    expect(getRemainingHp(primary)).toBe(0) // overkilled, so it drops out of engagedWith too
     expect(battle.carryoverTargets()).toEqual([included])
   })
 
@@ -531,22 +531,22 @@ describe("Battle phase transitions", () => {
 
     battle.nextPhase()
     expectPhase(BattlePhase.DEFENDER_STRIKE, 0)
-    centaur.performStrike() // stand in for an actual strike() call - only hasStruck matters here
+    performStrike(centaur) // stand in for an actual strike() call - only hasStruck matters here
 
     battle.nextPhase()
     expectPhase(BattlePhase.ATTACKER_STRIKEBACK, 0)
-    lion.performStrike()
+    performStrike(lion)
 
     battle.nextPhase()
     expectPhase(BattlePhase.ATTACKER_MOVE, 0)
 
     battle.nextPhase()
     expectPhase(BattlePhase.ATTACKER_STRIKE, 0)
-    lion.performStrike()
+    performStrike(lion)
 
     battle.nextPhase()
     expectPhase(BattlePhase.DEFENDER_STRIKEBACK, 0)
-    centaur.performStrike()
+    performStrike(centaur)
 
     battle.nextPhase()
     expectPhase(BattlePhase.DEFENDER_MOVE, 1)

--- a/src/models/battle/engine.ts
+++ b/src/models/battle/engine.ts
@@ -16,7 +16,18 @@ import {
   isCreatureNative,
   relationToHex
 } from "./board"
-import { BattleCreature } from "./combatant"
+import {
+  BattleCreature,
+  createBattleCreature,
+  getRemainingHp,
+  getStrength,
+  performStrike,
+  phaseEnterMove,
+  phaseEnterStrike,
+  phaseExitMove,
+  phaseExitStrikeback,
+  wound
+} from "./combatant"
 import {
   ActiveStrike,
   BATTLE_PHASE_TYPES,
@@ -53,12 +64,12 @@ export class Battle {
     this.attackerEdge = terrain === Terrain.TOWER ? HexEdge.SECOND : edge
     this.attacker = attacking.player
     this.defender = defending.player
-    this.creatures = attacking.creatures.map(type => new BattleCreature({
+    this.creatures = attacking.creatures.map(type => createBattleCreature({
       type,
       player: attacking.player,
       playerScore: attacking.score,
       hex: 37 + this.attackerEdge * 2
-    })).concat(defending.creatures.map(type => new BattleCreature({
+    })).concat(defending.creatures.map(type => createBattleCreature({
       type,
       player: defending.player,
       playerScore: defending.score,
@@ -69,7 +80,7 @@ export class Battle {
   static hydrate(battle: Battle): Battle {
     const hydrated: Battle = Object.assign(Object.create(Battle.prototype) as Battle, {
       ...battle,
-      creatures: battle.creatures.map(creature => new BattleCreature(creature)),
+      creatures: battle.creatures.map(creature => createBattleCreature(creature)),
       activeStrike: battle.activeStrike === undefined ? undefined : new ActiveStrike(battle.activeStrike)
     })
     hydrated.creatureOnHex = memoize(hydrated.creatureOnHex)
@@ -144,20 +155,20 @@ export class Battle {
   }
 
   phaseEnterMove(): void {
-    this.getActiveCreatures().forEach(creature => creature.phaseEnterMove())
+    this.getActiveCreatures().forEach(creature => phaseEnterMove(creature))
   }
 
   phaseExitMove(): void {
-    this.getActiveCreatures().forEach(creature => creature.phaseExitMove())
+    this.getActiveCreatures().forEach(creature => phaseExitMove(creature))
   }
 
   phaseEnterStrike(): void {
     this.activeStrike = undefined
-    this.creatures.forEach(creature => creature.phaseEnterStrike())
+    this.creatures.forEach(creature => phaseEnterStrike(creature))
     if (this.terrain === Terrain.TUNDRA) {
       this.creatures
         .filter(creature => this.getBoard().getHazard(creature.hex) === Hazard.DRIFT)
-        .forEach(creature => creature.wound(1))
+        .forEach(creature => wound(creature, 1))
     }
   }
 
@@ -168,7 +179,7 @@ export class Battle {
 
   phaseExitStrikeback(): void {
     this.phaseExitStrike()
-    this.creatures.forEach(creature => creature.phaseExitStrikeback())
+    this.creatures.forEach(creature => phaseExitStrikeback(creature))
   }
 
   /** End Phase Manipulation **/
@@ -257,7 +268,7 @@ export class Battle {
     const hex = BATTLE_PHASE_TYPES[this.phase] === BattlePhaseType.MOVE ? whom.initialHex : whom.hex
     const adjacencies = BATTLE_BOARD_ADJACENCIES[hex]
     return this.creatures.filter(creature => creature.player !== whom.player &&
-      (includeDead || creature.getRemainingHp() > 0) &&
+      (includeDead || getRemainingHp(creature) > 0) &&
       adjacencies.includes(creature.hex) &&
       // TODO: only checks the cliff hazard in the fixed direction (whom -> creature), so it misses
       // cliffs where `creature` (not `whom`) is the upper hex - creatureMovementCost above shows the
@@ -303,7 +314,7 @@ export class Battle {
         return targetCreature !== undefined && targetCreature.player !== creature.player &&
           // Warlocks can rangestrike lords!
           (creature.type === CreatureType.WARLOCK || !CREATURE_DATA[targetCreature.type].lord) &&
-          targetCreature.getRemainingHp() > 0
+          getRemainingHp(targetCreature) > 0
       }
       return false
     }) as number[][]
@@ -504,7 +515,7 @@ export class Battle {
   getRawStrike(attacker: BattleCreature, defender: BattleCreature): Strike {
     return {
       toHit: this.toHitRaw(attacker, defender),
-      dice: attacker.getStrength()
+      dice: getStrength(attacker)
     }
   }
 
@@ -534,9 +545,9 @@ export class Battle {
   private performAttack(attacker: BattleCreature, defender: BattleCreature,
     rolls: number[], toHit: number, rangestrike: boolean): void {
     const totalHits = rolls.filter(roll => roll >= toHit).length
-    const hits = Math.min(totalHits, defender.getRemainingHp())
-    attacker.performStrike()
-    defender.wound(hits)
+    const hits = Math.min(totalHits, getRemainingHp(defender))
+    performStrike(attacker)
+    wound(defender, hits)
     this.activeStrike = new ActiveStrike({
       attacker: attacker.hex,
       target: defender.hex,
@@ -562,9 +573,9 @@ export class Battle {
     // Using an optional chain prevents typescript from learning that this.activeStrike is present
     assert(this.activeStrike !== undefined &&
       this.activeStrike.canCarryover, "Cannot carryover")
-    const hits = Math.min(this.activeStrike.getCarryoverHits(), target.getRemainingHp())
+    const hits = Math.min(this.activeStrike.getCarryoverHits(), getRemainingHp(target))
     this.activeStrike.carryover({ hits, target: target.hex })
-    target.wound(hits)
+    wound(target, hits)
   }
 
   rangestrike(attacker: BattleCreature, defender: RangestrikeTarget, rolls: number[]): void {


### PR DESCRIPTION
[`BattleCreature`](https://github.com/aolkin/warlord/blob/main/src/models/battle/combatant.ts) mixed serializable state (`hex`, `wounds`, `hasStruck`, `initialHex`) with rules methods (`wound`, `performStrike`, `getStrength`, `getRemainingHp`, the `phaseEnter*`/`phaseExit*` transitions) in one class, using declaration-merging to attach runtime-assigned fields to the type. This splits it into a plain `BattleCreature` state interface and standalone functions taking that state as their first argument, per the state/rules separation [proposals/04-state-management.md](https://github.com/aolkin/warlord/blob/main/proposals/04-state-management.md) calls for.

Call sites in [`engine.ts`](https://github.com/aolkin/warlord/blob/main/src/models/battle/engine.ts) and the battle Vue components move from method calls (`creature.wound(1)`) to function calls (`wound(creature, 1)`). [`StrikePanelTitle.vue`](https://github.com/aolkin/warlord/blob/main/src/components/game/battle/StrikePanelTitle.vue) also needed its prop `type: BattleCreature` validator changed to `type: Object as PropType<BattleCreature>`, since Vue's runtime prop-type checking previously relied on `BattleCreature` being a class constructor.

`src/models/game/battle.ts` needed no changes beyond what TypeScript already re-typechecks - it only ever held `BattleCreature` as a type annotation and used lodash's `matches()` for equality, which works the same on plain objects.

engine.test.ts's assertions are unchanged; only its call shape (`centaur.getRemainingHp()` → `getRemainingHp(centaur)`) was updated mechanically.