### PR TITLE
Have selection store watch game state instead of engine calling it

### DIFF
--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -9,7 +9,6 @@ import masterboard, { HexEdge, MasterboardHex } from "./masterboard"
 import { Player, PlayerId } from "./player"
 import { defaultRandom, Random } from "./random"
 import { MusterChoice, Stack } from "./stack"
-import { useSelectionStore } from "~/stores/ui/selection"
 
 const INITIAL_HEXES: Record<number, number[]> = {
   2: [100, 400],
@@ -322,7 +321,6 @@ export class TitanGame {
         commit("phaseExitMuster", getters)
     }
     commit("nextPhase", getters)
-    useSelectionStore().deselectStack()
     await this.persist()
   }
 

--- a/src/game/models/game/battle.ts
+++ b/src/game/models/game/battle.ts
@@ -1,6 +1,5 @@
 import { matches } from "lodash-es"
 import { assert } from "@/utils/assert"
-import { useSelectionStore, View } from "~/stores/ui/selection"
 import { Battle, BATTLE_PHASE_TYPES, BattleCreature, BattlePhaseType, BattleSide, RangestrikeTarget } from "../battle"
 import masterboard from "../masterboard"
 import { PlayerId } from "../player"
@@ -117,7 +116,6 @@ export const gameBattle: GameBattle & ThisType<TitanGame> = {
     assert(defending !== undefined,
       `No engagement present on hex ${attacking.hex}!`)
     commit("initiateBattle", { attacking, defending })
-    useSelectionStore().setView(View.BATTLEBOARD)
     await this.persist()
   },
 

--- a/src/ui/stores/ui/selection.ts
+++ b/src/ui/stores/ui/selection.ts
@@ -1,8 +1,8 @@
 import { defineStore } from "pinia"
-import { computed, ref, shallowReactive, shallowRef } from "vue"
+import { computed, ref, shallowReactive, shallowRef, watch } from "vue"
 import type { Store } from "vuex"
-import { BattleCreature, RangestrikeTarget } from "@/models/battle"
-import { Path } from "@/models/game"
+import { Battle, BattleCreature, RangestrikeTarget } from "@/models/battle"
+import { MasterboardPhase, Path } from "@/models/game"
 import masterboard, { MasterboardHex } from "@/models/masterboard"
 import { Stack } from "@/models/stack"
 
@@ -14,8 +14,9 @@ export enum View {
 // The "game" module (src/game/store/game) still lives in Vuex and is reflected off TitanGame's
 // prototype (see proposals/04-state-management.md), so its state and getters aren't typed
 // through Pinia. Importing the Vuex store instance directly here would cycle back through
-// store/game (which imports TitanGame, which imports this file for doNextPhase/doInitiateBattle),
-// so plugins/vuex.ts hands it to us at runtime via provideVuexStore instead of a static import.
+// plugins/vuex.ts, which itself imports this file (for provideVuexStore, and to call
+// useSelectionStore().reset() from its own "reset" action) - so plugins/vuex.ts hands us the
+// instance at runtime via provideVuexStore instead of a static import.
 // Vuex also types Store#getters as `any` and doesn't merge module state into Store#state's
 // type, so reads of the game module below go through a local cast to the shape TitanGame
 // actually exposes at runtime.
@@ -34,6 +35,10 @@ const requireVuexStore = (): Store<unknown> => {
 
 const activeRoll = (): number | undefined =>
   (requireVuexStore().state as unknown as { game: { activeRoll?: number } }).game.activeRoll
+const activePhase = (): MasterboardPhase =>
+  (requireVuexStore().state as unknown as { game: { activePhase: MasterboardPhase } }).game.activePhase
+const activeBattle = (): Battle | undefined =>
+  (requireVuexStore().state as unknown as { game: { activeBattle?: Battle } }).game.activeBattle
 const pathsForHex = (): (hex: number) => Path[] =>
   requireVuexStore().getters["game/pathsForHex"] as (hex: number) => Path[]
 const battleMoves = (): (creature: BattleCreature) => Set<number> =>
@@ -170,6 +175,16 @@ export const useSelectionStore = defineStore("selection", () => {
       focusedBattleHexes.splice(index)
     }
   }
+
+  watch(activePhase, deselectStack)
+
+  // Only the empty->present transition should navigate to the battle board - subsequent
+  // mutations within the same battle (strikes, wounds, etc.) also change activeBattle.
+  watch(() => activeBattle() !== undefined, (hasBattle, hadBattle) => {
+    if (hasBattle && !hadBattle) {
+      setView(View.BATTLEBOARD)
+    }
+  })
 
   return {
     view,


### PR DESCRIPTION
`TitanGame.doNextPhase` and `gameBattle.doInitiateBattle` in [`src/game/models/game.ts`](https://github.com/aolkin/warlord/blob/main/src/game/models/game.ts) and [`src/game/models/game/battle.ts`](https://github.com/aolkin/warlord/blob/main/src/game/models/game/battle.ts) called `useSelectionStore().deselectStack()` and `useSelectionStore().setView(View.BATTLEBOARD)` directly - two write-only UI side effects the game engine had no need to know about, and part of why [`src/ui/stores/ui/selection.ts`](https://github.com/aolkin/warlord/blob/main/src/ui/stores/ui/selection.ts) needed the `provideVuexStore`/`requireVuexStore` runtime-injection machinery.

Both calls are removed from the engine. The selection store now watches the same Vuex game state through the injection mechanism it already uses for other reads (`activeRoll`, `pathsForHex`, `battleMoves`, ...):

- A `watch(activePhase, deselectStack)` on `TitanGame#activePhase` replaces the phase-change call.
- A `watch(() => activeBattle() !== undefined, ...)` replaces the battle-initiation call, calling `setView(View.BATTLEBOARD)` only when the callback sees a `false -> true` transition. Deriving a boolean before watching (rather than watching `activeBattle` itself) keeps the effect from re-firing on in-battle mutations (strikes, wounds, etc.) that also touch `activeBattle` after it's set.

**Injection-machinery question**: `plugins/vuex.ts` still imports `selection.ts` for its own `reset` action (`useSelectionStore().reset()`), unrelated to this change. That import means a static import of the Vuex store instance back from `selection.ts` would recreate a two-file cycle (`vuex.ts` &harr; `selection.ts`) - the same shape of cycle the injection machinery was built to avoid, just shorter now that the engine no longer participates in it. I traced the rest of `src/game` and confirmed none of its modules import anything under `src/ui` anymore, so the injection machinery's only remaining reason is that `reset` action. Left it in place and updated the comment above it to describe the actual current cycle instead of the removed `doNextPhase`/`doInitiateBattle` path.

Lint, typecheck, tests, and build all pass locally. GitHub Actions did not dispatch a run for this branch after several minutes (`gh run list` stayed empty), consistent with the ongoing webhook-delivery outage - local verification is the fallback here.