### PR TITLE
Extract Battle strike-resolution mutators into free functions

### DIFF
--- a/src/game/models/battle.ts
+++ b/src/game/models/battle.ts
@@ -29,5 +29,5 @@ export {
 } from "./battle/strike"
 export type { ActiveStrikeHit, IActiveStrike, RangestrikeTarget, Strike } from "./battle/strike"
 
-export { Battle } from "./battle/engine"
+export { Battle, carryover, rangestrike, strike } from "./battle/engine"
 export type { BattleSide } from "./battle/engine"

--- a/src/game/models/battle/engine.test.ts
+++ b/src/game/models/battle/engine.test.ts
@@ -4,7 +4,7 @@ import { HexEdge, Terrain } from "@/models/masterboard"
 import { PlayerId } from "@/models/player"
 import { UNATTAINABLE_MOVEMENT_COST } from "./board"
 import { BattleCreature, performStrike } from "./combatant"
-import { Battle, BattleSide } from "./engine"
+import { Battle, BattleSide, carryover, rangestrike, strike } from "./engine"
 import { BattlePhase } from "./strike"
 
 function setupBattle(terrain: Terrain, attackerTypes: CreatureType[], defenderTypes: CreatureType[]): {
@@ -47,7 +47,7 @@ describe("Battle engagement", () => {
 
     const toHit = battle.toHitAdjusted(lion, centaur)
     expect(toHit).toBe(5) // 4 - (lion skill 3 - centaur skill 4), no terrain adjustment
-    battle.strike(lion, centaur, [6, 6, 6, 6, 6])
+    strike(battle, lion, centaur, [6, 6, 6, 6, 6])
 
     expect(lion.hasStruck).toBe(true)
     expect(centaur.wounds).toBe(3) // Centaur's full strength (3); capped, not overkill
@@ -246,14 +246,14 @@ describe("Carryover", () => {
   it("assigns overflow hits from an overkill strike to another engaged target", () => {
     const { battle, lion, centaur1, centaur2 } = setupTripleEngagement()
 
-    battle.strike(lion, centaur1, [6, 6, 6, 6, 6])
+    strike(battle, lion, centaur1, [6, 6, 6, 6, 6])
     expect(centaur1.getRemainingHp()).toBe(0)
     expect(battle.activeStrike?.canCarryover).toBe(true)
     // getCarryoverHits = 5 total hits - 3 assigned to centaur1
     expect(battle.activeStrike?.getCarryoverHits()).toBe(2)
     expect(battle.carryoverTargets()).toEqual([centaur2])
 
-    battle.carryover(centaur2)
+    carryover(battle, centaur2)
     expect(centaur2.wounds).toBe(2)
     expect(battle.activeStrike?.canCarryover).toBe(false) // no hits left to carry over
   })
@@ -261,7 +261,7 @@ describe("Carryover", () => {
   it("stops carryover once skipCarryover is called", () => {
     const { battle, lion, centaur1 } = setupTripleEngagement()
 
-    battle.strike(lion, centaur1, [6, 6, 6, 6, 6])
+    strike(battle, lion, centaur1, [6, 6, 6, 6, 6])
     expect(battle.activeStrike?.canCarryover).toBe(true)
 
     battle.activeStrike?.skipCarryover()
@@ -465,7 +465,7 @@ describe("Engagement edge cases", () => {
     place(included, 3) // toHit 5, no hazard - matches the rolled toHit, so carryover-eligible
     place(excluded, 8) // toHit 6, raised by the wall - harder than the rolled toHit
 
-    battle.strike(lion, primary, [6, 6, 6, 6, 6])
+    strike(battle, lion, primary, [6, 6, 6, 6, 6])
     expect(primary.getRemainingHp()).toBe(0) // overkilled, so it drops out of engagedWith too
     expect(battle.carryoverTargets()).toEqual([included])
   })
@@ -480,10 +480,10 @@ describe("Engagement edge cases", () => {
 
     const computedToHit = battle.toHitAdjusted(lion, centaur)
     expect(computedToHit).toBe(5)
-    expect(() => battle.strike(lion, centaur, [6, 6, 6, 6, 6], computedToHit - 1))
+    expect(() => strike(battle, lion, centaur, [6, 6, 6, 6, 6], computedToHit - 1))
       .toThrow("Cannot choose a lower to-hit")
 
-    battle.strike(lion, centaur, [6, 6, 6, 6, 6], computedToHit + 1)
+    strike(battle, lion, centaur, [6, 6, 6, 6, 6], computedToHit + 1)
     expect(battle.activeStrike?.toHit).toBe(computedToHit + 1)
     // A roll of 6 still clears the raised toHit of 6, so all 5 dice hit (capped at HP 3).
     expect(centaur.wounds).toBe(3)
@@ -502,7 +502,7 @@ describe("Engagement edge cases", () => {
     // Ranger has strength 4, so per rule 12.2 (dice = floor(power / 2)) a rangestrike rolls
     // exactly 2 dice.
     expect(battle.getRangestrike(ranger, targets[0]).dice).toBe(2)
-    battle.rangestrike(ranger, targets[0], [6, 6])
+    rangestrike(battle, ranger, targets[0], [6, 6])
 
     expect(ranger.hasStruck).toBe(true)
     expect(centaur.wounds).toBe(2)

--- a/src/game/models/battle/engine.ts
+++ b/src/game/models/battle/engine.ts
@@ -545,46 +545,48 @@ export class Battle {
     }
   }
 
-  // TODO: rolls is never validated against the strike's expected dice count (see
-  // getAdjustedStrike/getRangestrike), so a caller can pass the wrong number of dice unnoticed.
-  private performAttack(attacker: BattleCreature, defender: BattleCreature,
-    rolls: number[], toHit: number, rangestrike: boolean): void {
-    const totalHits = rolls.filter(roll => roll >= toHit).length
-    const hits = Math.min(totalHits, defender.getRemainingHp())
-    performStrike(attacker)
-    wound(defender, hits)
-    this.activeStrike = new ActiveStrike({
-      attacker: attacker.hex,
-      target: defender.hex,
-      totalHits,
-      hits,
-      toHit,
-      rolls,
-      rangestrike
-    })
-  }
+}
 
-  strike(attacker: BattleCreature, defender: BattleCreature,
-    rolls: number[], optionalToHit?: number): void {
-    let toHit = this.toHitAdjusted(attacker, defender)
-    if (optionalToHit !== undefined) {
-      assert(optionalToHit >= toHit, "Cannot choose a lower to-hit")
-      toHit = optionalToHit
-    }
-    this.performAttack(attacker, defender, rolls, toHit, false)
-  }
+// TODO: rolls is never validated against the strike's expected dice count (see
+// getAdjustedStrike/getRangestrike), so a caller can pass the wrong number of dice unnoticed.
+function performAttack(battle: Battle, attacker: BattleCreature, defender: BattleCreature,
+  rolls: number[], toHit: number, rangestrike: boolean): void {
+  const totalHits = rolls.filter(roll => roll >= toHit).length
+  const hits = Math.min(totalHits, defender.getRemainingHp())
+  performStrike(attacker)
+  wound(defender, hits)
+  battle.activeStrike = new ActiveStrike({
+    attacker: attacker.hex,
+    target: defender.hex,
+    totalHits,
+    hits,
+    toHit,
+    rolls,
+    rangestrike
+  })
+}
 
-  carryover(target: BattleCreature): void {
-    // Using an optional chain prevents typescript from learning that this.activeStrike is present
-    assert(this.activeStrike !== undefined &&
-      this.activeStrike.canCarryover, "Cannot carryover")
-    const hits = Math.min(this.activeStrike.getCarryoverHits(), target.getRemainingHp())
-    this.activeStrike.carryover({ hits, target: target.hex })
-    wound(target, hits)
+export function strike(battle: Battle, attacker: BattleCreature, defender: BattleCreature,
+  rolls: number[], optionalToHit?: number): void {
+  let toHit = battle.toHitAdjusted(attacker, defender)
+  if (optionalToHit !== undefined) {
+    assert(optionalToHit >= toHit, "Cannot choose a lower to-hit")
+    toHit = optionalToHit
   }
+  performAttack(battle, attacker, defender, rolls, toHit, false)
+}
 
-  rangestrike(attacker: BattleCreature, defender: RangestrikeTarget, rolls: number[]): void {
-    const strike = this.getRangestrike(attacker, defender)
-    this.performAttack(attacker, defender.creature, rolls, strike.toHit, true)
-  }
+export function carryover(battle: Battle, target: BattleCreature): void {
+  // Using an optional chain prevents typescript from learning that battle.activeStrike is present
+  assert(battle.activeStrike !== undefined &&
+    battle.activeStrike.canCarryover, "Cannot carryover")
+  const hits = Math.min(battle.activeStrike.getCarryoverHits(), target.getRemainingHp())
+  battle.activeStrike.carryover({ hits, target: target.hex })
+  wound(target, hits)
+}
+
+export function rangestrike(battle: Battle, attacker: BattleCreature, defender: RangestrikeTarget,
+  rolls: number[]): void {
+  const computedStrike = battle.getRangestrike(attacker, defender)
+  performAttack(battle, attacker, defender.creature, rolls, computedStrike.toHit, true)
 }

--- a/src/game/models/game/battle.ts
+++ b/src/game/models/game/battle.ts
@@ -1,6 +1,6 @@
 import { matches } from "lodash-es"
 import { assert } from "@/utils/assert"
-import { Battle, BATTLE_PHASE_TYPES, BattleCreature, BattlePhaseType, BattleSide, RangestrikeTarget } from "../battle"
+import { Battle, BATTLE_PHASE_TYPES, BattleCreature, BattlePhaseType, BattleSide, RangestrikeTarget, carryover, rangestrike, strike } from "../battle"
 import masterboard from "../masterboard"
 import { PlayerId } from "../player"
 import { Stack } from "../stack"
@@ -92,18 +92,18 @@ export const gameBattle: GameBattle & ThisType<TitanGame> = {
   mAttackCreature({ attacker, target, rolls, optionalToHit }: AttackPayload): void {
     assert(this.activeBattle?.creatures.some(matches(attacker)) ?? false, "Unexpected attacker")
     assert(this.activeBattle?.creatures.some(matches(target)) ?? false, "Unexpected defender")
-    this.activeBattle?.strike(attacker, target, rolls, optionalToHit)
+    strike(this.activeBattle!, attacker, target, rolls, optionalToHit)
   },
 
   mRangestrikeCreature({ attacker, target, rolls }: RangestrikePayload): void {
     assert(this.activeBattle?.creatures.some(matches(attacker)) ?? false, "Unexpected attacker")
     assert(this.activeBattle?.creatures.some(matches(target.creature)) ?? false, "Unexpected defender")
-    this.activeBattle?.rangestrike(attacker, target, rolls)
+    rangestrike(this.activeBattle!, attacker, target, rolls)
   },
 
   mAssignCarryover(target: BattleCreature): void {
     assert(this.activeBattle?.creatures.some(matches(target)) ?? false, "Unexpected target")
-    this.activeBattle?.carryover(target)
+    carryover(this.activeBattle!, target)
   },
 
   mSkipCarryover(): void {


### PR DESCRIPTION
Following the split established in [#81](https://github.com/aolkin/warlord/pull/81) for `BattleCreature` and [#82](https://github.com/aolkin/warlord/pull/82) for phase mutators, [`strike`](https://github.com/aolkin/warlord/blob/main/src/game/models/battle/engine.ts), [`carryover`](https://github.com/aolkin/warlord/blob/main/src/game/models/battle/engine.ts), and [`rangestrike`](https://github.com/aolkin/warlord/blob/main/src/game/models/battle/engine.ts) become free functions taking `Battle` explicitly, since each is called from more than one place (`engine.test.ts` plus `src/game/models/game/battle.ts`).

`performAttack` gets the same treatment even though it's private: it's called from both `strike` and `rangestrike`, so like `phaseExitStrike` in #82 it stays a module-private free function rather than being inlined into either caller.

Derivation methods and the phase mutators already extracted in #82 are untouched.