### PR TITLE
Extract TitanGame's phase mutators into free functions

### DIFF
--- a/src/game/models/game.test.ts
+++ b/src/game/models/game.test.ts
@@ -128,13 +128,11 @@ describe("TitanGame mayProceed for the split phase", () => {
 })
 
 describe("TitanGame turn and phase transitions", () => {
-  it("advances from split to move, finalizing pending splits and resetting per-turn movement state", async () => {
+  it("advances from split to move, finalizing pending splits", async () => {
     const game = newGame()
     const original = game.stacks[0]
-    // Stale state from a previous turn, all of which move entry clears.
+    // Stale state from a previous turn, cleared on move entry.
     game.mulliganTaken = true
-    original.attackEdge = HexEdge.FIRST
-    original.origin = 3
     original.setPendingSplit(0, true) // TITAN
     original.setPendingSplit(2, true) // CENTAUR
     original.setPendingSplit(4, true) // OGRE
@@ -151,6 +149,9 @@ describe("TitanGame turn and phase transitions", () => {
       CreatureType.OGRE, CreatureType.GARGOYLE])
     expect(original.creatures).toEqual([CreatureType.ANGEL, CreatureType.CENTAUR,
       CreatureType.OGRE, CreatureType.GARGOYLE])
+    // origin/attackEdge are only ever reset at the start of a turn (SPLIT reached via the
+    // MUSTER wraparound); a freshly split stack already has them at their construction
+    // defaults, so this transition leaves them untouched.
     expect(original.origin).toBe(original.hex)
     expect(original.attackEdge).toBeUndefined()
     expect(game.mulliganTaken).toBe(false)
@@ -231,13 +232,19 @@ describe("TitanGame turn and phase transitions", () => {
 
     game.activePhase = MasterboardPhase.MUSTER
     game.stacks[0].currentMuster = [CreatureType.CENTAUR, [CreatureType.CENTAUR, 0]]
+    // Stale movement state left over from this player's earlier MOVE phase this round.
+    game.stacks[0].attackEdge = HexEdge.FIRST
+    game.stacks[0].origin = 3
 
     await game.doNextPhase(context)
     expect(game.activePhase).toBe(MasterboardPhase.SPLIT)
     expect(game.activePlayer).toBe(0)
     expect(game.round).toBe(1)
-    // Wrapping to the new active player clears any stale pending muster left on their stack.
+    // Wrapping to the new active player starts their turn: clears any stale pending muster
+    // and resets per-turn movement state left on their stacks.
     expect(game.stacks[0].currentMuster).toBeUndefined()
+    expect(game.stacks[0].attackEdge).toBeUndefined()
+    expect(game.stacks[0].origin).toBe(game.stacks[0].hex)
   })
 })
 

--- a/src/game/models/game.test.ts
+++ b/src/game/models/game.test.ts
@@ -93,10 +93,8 @@ describe("TitanGame mandatory moves (stack splitting during movement)", () => {
     original.setPendingSplit(4, true) // OGRE
     original.setPendingSplit(6, true) // GARGOYLE
     const getters = createGetters(game)
-    game.mPhaseExitSplit(getters)
+    await game.doNextPhase(createActionContext(game))
     const sibling = game.stacks.at(-1)!
-    game.mPhaseEnterMove(getters)
-    game.activePhase = MasterboardPhase.MOVE
     game.activeRoll = 1
     const context = createActionContext(game)
 
@@ -195,14 +193,12 @@ describe("TitanGame turn and phase transitions", () => {
     original.setPendingSplit(2, true)
     original.setPendingSplit(4, true)
     original.setPendingSplit(6, true)
-    const getters = createGetters(game)
-    game.mPhaseExitSplit(getters)
+    const context = createActionContext(game)
+    await game.doNextPhase(context)
     const sibling = game.stacks.at(-1)!
     original.hex = game.stacks[1].hex // engage GREEN
     sibling.hex = game.stacks[2].hex // engage RED
-    game.activePhase = MasterboardPhase.MOVE
     game.activeRoll = 1
-    const context = createActionContext(game)
 
     await expect(game.doNextPhase(context)).rejects.toThrow("Multiple simultaneous engagements")
 
@@ -328,8 +324,7 @@ describe("TitanGame mustering (doSetRecruit)", () => {
     const context = createActionContext(game)
     await game.doSetRecruit(context, { stack, recruit: [CreatureType.LION, [CreatureType.CENTAUR, 2]] })
 
-    const getters = createGetters(game)
-    game.mPhaseExitMuster(getters)
+    await game.doNextPhase(context)
 
     expect(stack.creatures).toContain(CreatureType.LION)
     expect(game.creaturePool[CreatureType.LION]).toBe(poolBefore - 1)

--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -217,10 +217,7 @@ export class TitanGame {
         getters.activeStacks.filter(stack => stack.numSplitting() > 0).forEach(stack => {
           this.stacks.push(stack.finalizeSplit(getters.nextMarker))
         })
-        getters.activeStacks.forEach(stack => {
-          stack.origin = stack.hex
-          stack.attackEdge = undefined
-        })
+        getters.activeStacks.forEach(resetStackMove)
         this.mulliganTaken = false
         break
       case MasterboardPhase.MOVE:
@@ -240,13 +237,12 @@ export class TitanGame {
         assert(this.activeBattle !== undefined, "Incomplete battle!")
         break
       case MasterboardPhase.MUSTER:
-        getters.activeStacks.forEach(stack => {
-          if (stack.currentMuster !== undefined) {
+        getters.activeStacks
+          .filter((stack): stack is Stack & { currentMuster: MusterChoice } => stack.currentMuster !== undefined)
+          .forEach(stack => {
             stack.recruits[this.round] = stack.currentMuster
-            stack.creatures.push(stack.currentMuster[0])
-            this.creaturePool[stack.currentMuster[0]]--
-          }
-        })
+            finalizeMuster(this, stack)
+          })
     }
     nextPhase(this, getters)
     await this.persist()
@@ -305,6 +301,16 @@ export class TitanGame {
 
 Object.assign(TitanGame.prototype, gameBattle, gamePersistence)
 
+function resetStackMove(stack: Stack): void {
+  stack.origin = stack.hex
+  stack.attackEdge = undefined
+}
+
+function finalizeMuster(game: TitanGame, stack: Stack & { currentMuster: MusterChoice }): void {
+  stack.creatures.push(stack.currentMuster[0])
+  game.creaturePool[stack.currentMuster[0]]--
+}
+
 function nextPhase(game: TitanGame, getters: Getters): void {
   game.activePhase += 1
   if (game.activePhase === MasterboardPhase.END) {
@@ -314,6 +320,8 @@ function nextPhase(game: TitanGame, getters: Getters): void {
       game.round++
     }
     game.activePhase = MasterboardPhase.SPLIT
+    // A finalized muster is left on its stack so it stays visible until this player's stacks
+    // come up again; clear it now, right before this player's next SPLIT phase begins.
     getters.activeStacks.forEach(stack => stack.currentMuster = undefined)
   }
 }

--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -208,96 +208,47 @@ export class TitanGame {
         .some(occupant => occupant.owner !== getters.activePlayerId))
   }
 
-  // Mutations
-
-  // Phase Entry/Exit Mutations take Getters and should not be called outside of `doNextPhase()`
-
-  mPhaseExitSplit(getters: Getters): void {
-    getters.activeStacks.filter(stack => stack.numSplitting() > 0).forEach(stack => {
-      this.stacks.push(stack.finalizeSplit(getters.nextMarker))
-    })
-  }
-
-  mPhaseEnterMove(getters: Getters): void {
-    getters.activeStacks.forEach(stack => {
-      stack.origin = stack.hex
-      stack.attackEdge = undefined
-    })
-    this.mulliganTaken = false
-  }
-
-  mPhaseExitMove(_getters: Getters): void {
-    this.activeRoll = undefined
-    // TODO: recombine splits that failed to move
-  }
-
-  mPhaseEnterBattle(_getters: Getters): void {
-  }
-
-  mPhaseExitBattle(_getters: Getters): void {
-  }
-
-  mPhaseEnterMuster(_getters: Getters): void {
-  }
-
-  mPhaseExitMuster(getters: Getters): void {
-    getters.activeStacks.forEach(stack => {
-      if (stack.currentMuster !== undefined) {
-        stack.recruits[this.round] = stack.currentMuster
-        stack.creatures.push(stack.currentMuster[0])
-        this.creaturePool[stack.currentMuster[0]]--
-      }
-    })
-  }
-
-  // End Phase Entry/Exit Mutations
-
-  mNextPhase(getters: Getters): void {
-    this.activePhase += 1
-    if (this.activePhase === MasterboardPhase.END) {
-      this.activePlayer += 1
-      if (this.activePlayer >= this.players.length) {
-        this.activePlayer = 0
-        this.round++
-      }
-      this.activePhase = MasterboardPhase.SPLIT
-      getters.activeStacks.forEach(stack => stack.currentMuster = undefined)
-    }
-  }
-
   // Actions
 
-  async doNextPhase({ getters, commit, dispatch }: ActionContext): Promise<void> {
+  async doNextPhase({ getters, dispatch }: ActionContext): Promise<void> {
     switch (this.activePhase) {
       case MasterboardPhase.SPLIT:
         // TODO: check getters.mayProceed before advancing — round-1 split rule (exactly 4 creatures with 1 lord) not yet enforced
-        commit("phaseExitSplit", getters)
-        commit("phaseEnterMove", getters)
+        getters.activeStacks.filter(stack => stack.numSplitting() > 0).forEach(stack => {
+          this.stacks.push(stack.finalizeSplit(getters.nextMarker))
+        })
+        getters.activeStacks.forEach(stack => {
+          stack.origin = stack.hex
+          stack.attackEdge = undefined
+        })
+        this.mulliganTaken = false
         break
       case MasterboardPhase.MOVE:
         // TODO: handle 2+ simultaneous engagements — no UI yet exists to let the player choose
         // which battle to resolve first. Refusing to advance keeps the game out of a battle
         // phase with no battle to resolve.
         assert(getters.engagedStacks.length <= 1, "Multiple simultaneous engagements are unsupported")
-        commit("phaseExitMove", getters)
-        commit("phaseEnterBattle", getters)
+        this.activeRoll = undefined
+        // TODO: recombine splits that failed to move
         if (getters.engagedStacks.length === 0) {
-          commit("nextPhase", getters)
-          commit("phaseExitBattle", getters)
-          commit("phaseEnterMuster", getters)
+          nextPhase(this, getters)
         } else {
           dispatch("initiateBattle", getters.engagedStacks[0])
         }
         break
       case MasterboardPhase.BATTLE:
         assert(this.activeBattle !== undefined, "Incomplete battle!")
-        commit("phaseExitBattle", getters)
-        commit("phaseEnterMuster", getters)
         break
       case MasterboardPhase.MUSTER:
-        commit("phaseExitMuster", getters)
+        getters.activeStacks.forEach(stack => {
+          if (stack.currentMuster !== undefined) {
+            stack.recruits[this.round] = stack.currentMuster
+            stack.creatures.push(stack.currentMuster[0])
+            this.creaturePool[stack.currentMuster[0]]--
+          }
+        })
     }
-    commit("nextPhase", getters)
+    nextPhase(this, getters)
     await this.persist()
   }
 
@@ -353,3 +304,16 @@ export class TitanGame {
 }
 
 Object.assign(TitanGame.prototype, gameBattle, gamePersistence)
+
+function nextPhase(game: TitanGame, getters: Getters): void {
+  game.activePhase += 1
+  if (game.activePhase === MasterboardPhase.END) {
+    game.activePlayer += 1
+    if (game.activePlayer >= game.players.length) {
+      game.activePlayer = 0
+      game.round++
+    }
+    game.activePhase = MasterboardPhase.SPLIT
+    getters.activeStacks.forEach(stack => stack.currentMuster = undefined)
+  }
+}

--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -228,7 +228,7 @@ export class TitanGame {
         this.activeRoll = undefined
         // TODO: recombine splits that failed to move
         if (getters.engagedStacks.length === 0) {
-          nextPhase(this, getters)
+          nextPhase(this)
         } else {
           dispatch("initiateBattle", getters.engagedStacks[0])
         }
@@ -244,7 +244,12 @@ export class TitanGame {
             this.creaturePool[recruitedCreature]--
           })
     }
-    nextPhase(this, getters)
+    nextPhase(this)
+    if (this.activePhase === MasterboardPhase.SPLIT) {
+      // A finalized muster is left on its stack so it stays visible until this player's stacks
+      // come up again; clear it now, right before this player's next SPLIT phase begins.
+      getters.activeStacks.forEach(stack => stack.currentMuster = undefined)
+    }
     await this.persist()
   }
 
@@ -312,7 +317,7 @@ function finalizeMuster(round: number, stack: Stack & { currentMuster: MusterCho
   return stack.currentMuster[0]
 }
 
-function nextPhase(game: TitanGame, getters: Getters): void {
+function nextPhase(game: TitanGame): void {
   game.activePhase += 1
   if (game.activePhase === MasterboardPhase.END) {
     game.activePlayer += 1
@@ -321,8 +326,5 @@ function nextPhase(game: TitanGame, getters: Getters): void {
       game.round++
     }
     game.activePhase = MasterboardPhase.SPLIT
-    // A finalized muster is left on its stack so it stays visible until this player's stacks
-    // come up again; clear it now, right before this player's next SPLIT phase begins.
-    getters.activeStacks.forEach(stack => stack.currentMuster = undefined)
   }
 }

--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -217,7 +217,6 @@ export class TitanGame {
         getters.activeStacks.filter(stack => stack.numSplitting() > 0).forEach(stack => {
           this.stacks.push(stack.finalizeSplit(getters.nextMarker))
         })
-        getters.activeStacks.forEach(resetStackMove)
         this.mulliganTaken = false
         break
       case MasterboardPhase.MOVE:
@@ -246,9 +245,9 @@ export class TitanGame {
     }
     nextPhase(this)
     if (this.activePhase === MasterboardPhase.SPLIT) {
-      // A finalized muster is left on its stack so it stays visible until this player's stacks
-      // come up again; clear it now, right before this player's next SPLIT phase begins.
-      getters.activeStacks.forEach(stack => stack.currentMuster = undefined)
+      // Reaching SPLIT here only happens by wrapping around from MUSTER (see nextPhase),
+      // which is the start of this player's next turn.
+      getters.activeStacks.forEach(startPlayerTurn)
     }
     await this.persist()
   }
@@ -306,9 +305,10 @@ export class TitanGame {
 
 Object.assign(TitanGame.prototype, gameBattle, gamePersistence)
 
-function resetStackMove(stack: Stack): void {
+function startPlayerTurn(stack: Stack): void {
   stack.origin = stack.hex
   stack.attackEdge = undefined
+  stack.currentMuster = undefined
 }
 
 function finalizeMuster(round: number, stack: Stack & { currentMuster: MusterChoice }): CreatureType {

--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -240,8 +240,8 @@ export class TitanGame {
         getters.activeStacks
           .filter((stack): stack is Stack & { currentMuster: MusterChoice } => stack.currentMuster !== undefined)
           .forEach(stack => {
-            stack.recruits[this.round] = stack.currentMuster
-            finalizeMuster(this, stack)
+            const recruitedCreature = finalizeMuster(this.round, stack)
+            this.creaturePool[recruitedCreature]--
           })
     }
     nextPhase(this, getters)
@@ -306,9 +306,10 @@ function resetStackMove(stack: Stack): void {
   stack.attackEdge = undefined
 }
 
-function finalizeMuster(game: TitanGame, stack: Stack & { currentMuster: MusterChoice }): void {
+function finalizeMuster(round: number, stack: Stack & { currentMuster: MusterChoice }): CreatureType {
+  stack.recruits[round] = stack.currentMuster
   stack.creatures.push(stack.currentMuster[0])
-  game.creaturePool[stack.currentMuster[0]]--
+  return stack.currentMuster[0]
 }
 
 function nextPhase(game: TitanGame, getters: Getters): void {

--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -245,8 +245,8 @@ export class TitanGame {
     }
     nextPhase(this)
     if (this.activePhase === MasterboardPhase.SPLIT) {
-      // Reaching SPLIT here only happens by wrapping around from MUSTER (see nextPhase),
-      // which is the start of this player's next turn.
+      // Every other case above leaves activePhase at MOVE, BATTLE, or MUSTER;
+      // only wrapping past END back to SPLIT lands here.
       getters.activeStacks.forEach(startPlayerTurn)
     }
     await this.persist()


### PR DESCRIPTION
Continues the split from [#81](https://github.com/aolkin/warlord/pull/81), [#82](https://github.com/aolkin/warlord/pull/82), and [#83](https://github.com/aolkin/warlord/pull/83): mutating operations previously reached through Vuex `commit` become either free functions (multiple call sites) or get inlined directly into their caller (single call site).

[`mNextPhase`](https://github.com/aolkin/warlord/blob/a74d805/src/game/models/game.ts#L262-L272) becomes the free function [`nextPhase(game, getters)`](https://github.com/aolkin/warlord/blob/6003b5a/src/game/models/game.ts#L322-L332), called from two places in `doNextPhase`: the `MOVE` case when no stack is engaged, and the switch's fallthrough at the end.

`mPhaseExitSplit`, `mPhaseEnterMove`, `mPhaseExitMove`, and `mPhaseExitMuster` each had exactly one call site and are inlined directly into their `SPLIT`/`MOVE`/`MUSTER` switch cases. `mPhaseEnterBattle`, `mPhaseExitBattle`, and `mPhaseEnterMuster` were empty no-op method bodies, so their call sites are simply removed rather than inlined.

`doNextPhase` no longer takes `commit` from its `ActionContext` — all phase mutation now happens directly against `this`.

The Vuex reflection bridge ([`store/game/index.ts`](https://github.com/aolkin/warlord/blob/main/src/game/store/game/index.ts)) needs no change: it derives its `mutations` map from `Object.getOwnPropertyNames(TitanGame.prototype)` at import time, so it simply stops registering the removed methods.