### PR TITLE
Inline TitanGame's single-call-site roll/move/muster mutators

### DIFF
--- a/src/game/models/game.test.ts
+++ b/src/game/models/game.test.ts
@@ -144,7 +144,7 @@ describe("TitanGame movement legality", () => {
 })
 
 describe("TitanGame mandatory moves (stack splitting during movement)", () => {
-  it("requires splitting apart two stacks sharing a hex until one of them moves away", () => {
+  it("requires splitting apart two stacks sharing a hex until one of them moves away", async () => {
     const game = newGame()
     const original = game.stacks[0]
     original.setPendingSplit(0, true) // TITAN
@@ -157,12 +157,13 @@ describe("TitanGame mandatory moves (stack splitting during movement)", () => {
     game.mPhaseEnterMove(getters)
     game.activePhase = MasterboardPhase.MOVE
     game.activeRoll = 1
+    const context = createActionContext(game)
 
     expect(getters.mandatoryMoves).toEqual(expect.arrayContaining([original, sibling]))
     expect(getters.mandatoryMoves).toHaveLength(2)
     expect(getters.mayProceed).toBe(false)
 
-    game.mMove({ stack: original, hex: 3 })
+    await game.doMove(context, { stack: original, hex: 3 })
 
     // Once split apart, the remaining stack alone on the origin hex is no longer mandatory.
     expect(getters.mandatoryMoves).toEqual([])
@@ -303,6 +304,30 @@ describe("TitanGame turn and phase transitions", () => {
   })
 })
 
+describe("TitanGame roll setting (doSetRoll)", () => {
+  it("records the roll during the move phase", async () => {
+    const game = newGame()
+    game.activePhase = MasterboardPhase.MOVE
+    const context = createActionContext(game)
+
+    await game.doSetRoll(context, 4)
+
+    expect(game.activeRoll).toBe(4)
+  })
+
+  it("taking a mulligan clears the roll and marks it taken", async () => {
+    const game = newGame()
+    game.activePhase = MasterboardPhase.MOVE
+    game.activeRoll = 3
+    const context = createActionContext(game)
+
+    await game.doSetRoll(context, undefined)
+
+    expect(game.activeRoll).toBeUndefined()
+    expect(game.mulliganTaken).toBe(true)
+  })
+})
+
 describe("TitanGame mustering (doSetRecruit)", () => {
   it("refuses to record a recruit for a stack that isn't eligible to muster", async () => {
     const game = newGame()
@@ -313,6 +338,19 @@ describe("TitanGame mustering (doSetRecruit)", () => {
     await expect(game.doSetRecruit(context, {
       stack, recruit: [CreatureType.CENTAUR, [CreatureType.CENTAUR, 0]]
     })).rejects.toThrow("not eligible to muster")
+  })
+
+  it("refuses to record a recruit outside the muster phase", async () => {
+    const game = newGame()
+    const stack = new Stack(game.players[0].id, 100, 1, [CreatureType.CENTAUR, CreatureType.CENTAUR])
+    stack.hex = 101 // moved, so otherwise eligible to muster
+    game.stacks.push(stack)
+    game.activePhase = MasterboardPhase.MOVE
+    const context = createActionContext(game)
+
+    await expect(game.doSetRecruit(context, {
+      stack, recruit: [CreatureType.LION, [CreatureType.CENTAUR, 2]]
+    })).rejects.toThrow("Innappropriate phase")
   })
 
   it.each([

--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -265,29 +265,6 @@ export class TitanGame {
     }
   }
 
-  mSetRoll(payload: number): void {
-    assert(this.activePhase === MasterboardPhase.MOVE, "Innappropriate phase")
-    if (payload === undefined && this.activeRoll !== undefined) {
-      this.mulliganTaken = true
-    }
-    this.activeRoll = payload
-  }
-
-  mMove({ stack, hex, edge }: MovePayload): void {
-    assert(this.activePhase === MasterboardPhase.MOVE, "Innappropriate phase")
-    stack.attackEdge = edge
-    if (hex instanceof MasterboardHex) {
-      stack.hex = hex.id
-    } else {
-      stack.hex = hex
-    }
-  }
-
-  mMuster({ stack, recruit }: MusterPayload): void {
-    assert(this.activePhase === MasterboardPhase.MUSTER, "Innappropriate phase")
-    stack.currentMuster = recruit
-  }
-
   // Actions
 
   async doNextPhase({ getters, commit, dispatch }: ActionContext): Promise<void> {
@@ -324,28 +301,39 @@ export class TitanGame {
     await this.persist()
   }
 
-  async doSetRoll({ getters, commit }: ActionContext, payload?: number): Promise<void> {
+  async doSetRoll({ getters }: ActionContext, payload?: number): Promise<void> {
     if (payload === undefined && this.activeRoll !== undefined) {
       assert(getters.mulliganAvailable, "Mulligan unavailable")
     }
-    commit("setRoll", payload)
+    assert(this.activePhase === MasterboardPhase.MOVE, "Innappropriate phase")
+    if (payload === undefined && this.activeRoll !== undefined) {
+      this.mulliganTaken = true
+    }
+    this.activeRoll = payload
     await this.persist()
   }
 
-  async doMove({ commit }: ActionContext, payload: MovePayload): Promise<void> {
-    commit("move", payload)
+  async doMove(_context: ActionContext, { stack, hex, edge }: MovePayload): Promise<void> {
+    assert(this.activePhase === MasterboardPhase.MOVE, "Innappropriate phase")
+    stack.attackEdge = edge
+    if (hex instanceof MasterboardHex) {
+      stack.hex = hex.id
+    } else {
+      stack.hex = hex
+    }
     await this.persist()
   }
 
-  async doSetRecruit({ commit }: ActionContext, payload: MusterPayload): Promise<void> {
-    if (!payload.stack.canMuster()) {
+  async doSetRecruit(_context: ActionContext, { stack, recruit }: MusterPayload): Promise<void> {
+    if (!stack.canMuster()) {
       throw new Error("Stack is not eligible to muster!")
     }
-    if (payload.recruit !== undefined &&
-      this.creaturePool[payload.recruit[0]] < 1 && !CREATURE_DATA[payload.recruit[0]].lord) {
+    if (recruit !== undefined &&
+      this.creaturePool[recruit[0]] < 1 && !CREATURE_DATA[recruit[0]].lord) {
       throw new Error("No more of the requested creature remaining")
     }
-    commit("muster", payload)
+    assert(this.activePhase === MasterboardPhase.MUSTER, "Innappropriate phase")
+    stack.currentMuster = recruit
     await this.persist()
   }
 


### PR DESCRIPTION
Second and final slice of the `TitanGame` mutator cleanup from [`proposals/04-state-management.md`](https://github.com/aolkin/warlord/blob/main/proposals/04-state-management.md), following #81 (BattleCreature), #82/#83 (Battle engine.ts), and #84 (TitanGame phase mutators).

`mSetRoll`, `mMove`, and `mMuster` each had exactly one caller — `doSetRoll`, `doMove`, and `doSetRecruit` respectively — so their bodies are folded directly into those actions instead of going through the Vuex-shaped `commit()` indirection. The [store reflection bridge](https://github.com/aolkin/warlord/blob/main/src/game/store/game/index.ts) needs no change since it derives its mutation/action list from `TitanGame.prototype` at import time.

`mMove` already had a direct unit test; `mSetRoll` and `mMuster` did not, so tests for their behavior (roll assignment, mulligan handling, and the muster phase guard) were added via `doSetRoll`/`doSetRecruit` before inlining, confirmed passing against the old mutator-based code, then kept passing after the inline.