### PR TITLE
Inline strike/carryover/rangestrike into their single call sites

### DIFF
--- a/src/game/models/battle.ts
+++ b/src/game/models/battle.ts
@@ -29,5 +29,5 @@ export {
 } from "./battle/strike"
 export type { ActiveStrikeHit, IActiveStrike, RangestrikeTarget, Strike } from "./battle/strike"
 
-export { Battle, carryover, nextPhase, rangestrike, strike } from "./battle/engine"
+export { Battle, nextPhase, performAttack } from "./battle/engine"
 export type { BattleSide } from "./battle/engine"

--- a/src/game/models/battle/engine.test.ts
+++ b/src/game/models/battle/engine.test.ts
@@ -1,11 +1,36 @@
 import { describe, expect, it } from "vitest"
 import { CREATURE_DATA, CreatureType } from "@/models/creature"
+import { createActionContext, newGame } from "@/models/game.testUtils"
 import { HexEdge, Terrain } from "@/models/masterboard"
 import { PlayerId } from "@/models/player"
 import { UNATTAINABLE_MOVEMENT_COST } from "./board"
 import { BattleCreature, performStrike } from "./combatant"
-import { Battle, BattleSide, carryover, nextPhase, phaseEnterStrike, rangestrike, strike } from "./engine"
-import { BattlePhase } from "./strike"
+import { Battle, BattleSide, nextPhase, phaseEnterStrike } from "./engine"
+import { BattlePhase, RangestrikeTarget } from "./strike"
+
+// strike/carryover/rangestrike are no longer part of the production API surface (their bodies
+// are inlined at their single call sites in game/battle.ts); these wrappers drive the same
+// behavior through a real TitanGame's mutators (via the same commit -> mFoo mapping the real
+// Vuex module uses) so the tests below don't need to change.
+function strike(battle: Battle, attacker: BattleCreature, target: BattleCreature,
+  rolls: number[], optionalToHit?: number): void {
+  const context = createActionContext(newGame())
+  context.state.activeBattle = battle
+  context.commit("attackCreature", { attacker, target, rolls, optionalToHit })
+}
+
+function carryover(battle: Battle, target: BattleCreature): void {
+  const context = createActionContext(newGame())
+  context.state.activeBattle = battle
+  context.commit("assignCarryover", target)
+}
+
+function rangestrike(battle: Battle, attacker: BattleCreature, target: RangestrikeTarget,
+  rolls: number[]): void {
+  const context = createActionContext(newGame())
+  context.state.activeBattle = battle
+  context.commit("rangestrikeCreature", { attacker, target, rolls })
+}
 
 function setupBattle(terrain: Terrain, attackerTypes: CreatureType[], defenderTypes: CreatureType[]): {
   battle: Battle

--- a/src/game/models/battle/engine.test.ts
+++ b/src/game/models/battle/engine.test.ts
@@ -1,35 +1,22 @@
 import { describe, expect, it } from "vitest"
 import { CREATURE_DATA, CreatureType } from "@/models/creature"
+import type { TitanGame } from "@/models/game"
 import { newGame } from "@/models/game.testUtils"
 import { HexEdge, Terrain } from "@/models/masterboard"
 import { PlayerId } from "@/models/player"
 import { UNATTAINABLE_MOVEMENT_COST } from "./board"
 import { BattleCreature, performStrike } from "./combatant"
 import { Battle, BattleSide, nextPhase, phaseEnterStrike } from "./engine"
-import { BattlePhase, RangestrikeTarget } from "./strike"
+import { BattlePhase } from "./strike"
 
 // strike/carryover/rangestrike are no longer part of the production API surface (their bodies
-// are inlined at their single call sites in game/battle.ts); these wrappers drive the same
-// behavior through a real TitanGame's mutators (mAttackCreature etc., called directly the same
-// way game.test.ts calls mPhaseExitSplit) so the tests below don't need to change.
-function strike(battle: Battle, attacker: BattleCreature, target: BattleCreature,
-  rolls: number[], optionalToHit?: number): void {
+// are inlined at their single call sites in game/battle.ts); tests that need to drive a strike
+// exercise the same mutators production code uses (mAttackCreature etc.) directly on a real
+// TitanGame, the same direct-call pattern game.test.ts uses for mPhaseExitSplit.
+function createGameWithActiveBattle(battle: Battle): TitanGame {
   const game = newGame()
   game.activeBattle = battle
-  game.mAttackCreature({ attacker, target, rolls, optionalToHit })
-}
-
-function carryover(battle: Battle, target: BattleCreature): void {
-  const game = newGame()
-  game.activeBattle = battle
-  game.mAssignCarryover(target)
-}
-
-function rangestrike(battle: Battle, attacker: BattleCreature, target: RangestrikeTarget,
-  rolls: number[]): void {
-  const game = newGame()
-  game.activeBattle = battle
-  game.mRangestrikeCreature({ attacker, target, rolls })
+  return game
 }
 
 function setupBattle(terrain: Terrain, attackerTypes: CreatureType[], defenderTypes: CreatureType[]): {
@@ -72,7 +59,8 @@ describe("Battle engagement", () => {
 
     const toHit = battle.toHitAdjusted(lion, centaur)
     expect(toHit).toBe(5) // 4 - (lion skill 3 - centaur skill 4), no terrain adjustment
-    strike(battle, lion, centaur, [6, 6, 6, 6, 6])
+    const game = createGameWithActiveBattle(battle)
+    game.mAttackCreature({ attacker: lion, target: centaur, rolls: [6, 6, 6, 6, 6] })
 
     expect(lion.hasStruck).toBe(true)
     expect(centaur.wounds).toBe(3) // Centaur's full strength (3); capped, not overkill
@@ -271,14 +259,15 @@ describe("Carryover", () => {
   it("assigns overflow hits from an overkill strike to another engaged target", () => {
     const { battle, lion, centaur1, centaur2 } = setupTripleEngagement()
 
-    strike(battle, lion, centaur1, [6, 6, 6, 6, 6])
+    const game = createGameWithActiveBattle(battle)
+    game.mAttackCreature({ attacker: lion, target: centaur1, rolls: [6, 6, 6, 6, 6] })
     expect(centaur1.getRemainingHp()).toBe(0)
     expect(battle.activeStrike?.canCarryover).toBe(true)
     // getCarryoverHits = 5 total hits - 3 assigned to centaur1
     expect(battle.activeStrike?.getCarryoverHits()).toBe(2)
     expect(battle.carryoverTargets()).toEqual([centaur2])
 
-    carryover(battle, centaur2)
+    game.mAssignCarryover(centaur2)
     expect(centaur2.wounds).toBe(2)
     expect(battle.activeStrike?.canCarryover).toBe(false) // no hits left to carry over
   })
@@ -286,7 +275,8 @@ describe("Carryover", () => {
   it("stops carryover once skipCarryover is called", () => {
     const { battle, lion, centaur1 } = setupTripleEngagement()
 
-    strike(battle, lion, centaur1, [6, 6, 6, 6, 6])
+    const game = createGameWithActiveBattle(battle)
+    game.mAttackCreature({ attacker: lion, target: centaur1, rolls: [6, 6, 6, 6, 6] })
     expect(battle.activeStrike?.canCarryover).toBe(true)
 
     battle.activeStrike?.skipCarryover()
@@ -490,7 +480,7 @@ describe("Engagement edge cases", () => {
     place(included, 3) // toHit 5, no hazard - matches the rolled toHit, so carryover-eligible
     place(excluded, 8) // toHit 6, raised by the wall - harder than the rolled toHit
 
-    strike(battle, lion, primary, [6, 6, 6, 6, 6])
+    createGameWithActiveBattle(battle).mAttackCreature({ attacker: lion, target: primary, rolls: [6, 6, 6, 6, 6] })
     expect(primary.getRemainingHp()).toBe(0) // overkilled, so it drops out of engagedWith too
     expect(battle.carryoverTargets()).toEqual([included])
   })
@@ -505,10 +495,14 @@ describe("Engagement edge cases", () => {
 
     const computedToHit = battle.toHitAdjusted(lion, centaur)
     expect(computedToHit).toBe(5)
-    expect(() => strike(battle, lion, centaur, [6, 6, 6, 6, 6], computedToHit - 1))
-      .toThrow("Cannot choose a lower to-hit")
+    const game = createGameWithActiveBattle(battle)
+    expect(() => game.mAttackCreature({
+      attacker: lion, target: centaur, rolls: [6, 6, 6, 6, 6], optionalToHit: computedToHit - 1
+    })).toThrow("Cannot choose a lower to-hit")
 
-    strike(battle, lion, centaur, [6, 6, 6, 6, 6], computedToHit + 1)
+    game.mAttackCreature({
+      attacker: lion, target: centaur, rolls: [6, 6, 6, 6, 6], optionalToHit: computedToHit + 1
+    })
     expect(battle.activeStrike?.toHit).toBe(computedToHit + 1)
     // A roll of 6 still clears the raised toHit of 6, so all 5 dice hit (capped at HP 3).
     expect(centaur.wounds).toBe(3)
@@ -527,7 +521,7 @@ describe("Engagement edge cases", () => {
     // Ranger has strength 4, so per rule 12.2 (dice = floor(power / 2)) a rangestrike rolls
     // exactly 2 dice.
     expect(battle.getRangestrike(ranger, targets[0]).dice).toBe(2)
-    rangestrike(battle, ranger, targets[0], [6, 6])
+    createGameWithActiveBattle(battle).mRangestrikeCreature({ attacker: ranger, target: targets[0], rolls: [6, 6] })
 
     expect(ranger.hasStruck).toBe(true)
     expect(centaur.wounds).toBe(2)

--- a/src/game/models/battle/engine.test.ts
+++ b/src/game/models/battle/engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { CREATURE_DATA, CreatureType } from "@/models/creature"
-import { createActionContext, newGame } from "@/models/game.testUtils"
+import { newGame } from "@/models/game.testUtils"
 import { HexEdge, Terrain } from "@/models/masterboard"
 import { PlayerId } from "@/models/player"
 import { UNATTAINABLE_MOVEMENT_COST } from "./board"
@@ -10,26 +10,26 @@ import { BattlePhase, RangestrikeTarget } from "./strike"
 
 // strike/carryover/rangestrike are no longer part of the production API surface (their bodies
 // are inlined at their single call sites in game/battle.ts); these wrappers drive the same
-// behavior through a real TitanGame's mutators (via the same commit -> mFoo mapping the real
-// Vuex module uses) so the tests below don't need to change.
+// behavior through a real TitanGame's mutators (mAttackCreature etc., called directly the same
+// way game.test.ts calls mPhaseExitSplit) so the tests below don't need to change.
 function strike(battle: Battle, attacker: BattleCreature, target: BattleCreature,
   rolls: number[], optionalToHit?: number): void {
-  const context = createActionContext(newGame())
-  context.state.activeBattle = battle
-  context.commit("attackCreature", { attacker, target, rolls, optionalToHit })
+  const game = newGame()
+  game.activeBattle = battle
+  game.mAttackCreature({ attacker, target, rolls, optionalToHit })
 }
 
 function carryover(battle: Battle, target: BattleCreature): void {
-  const context = createActionContext(newGame())
-  context.state.activeBattle = battle
-  context.commit("assignCarryover", target)
+  const game = newGame()
+  game.activeBattle = battle
+  game.mAssignCarryover(target)
 }
 
 function rangestrike(battle: Battle, attacker: BattleCreature, target: RangestrikeTarget,
   rolls: number[]): void {
-  const context = createActionContext(newGame())
-  context.state.activeBattle = battle
-  context.commit("rangestrikeCreature", { attacker, target, rolls })
+  const game = newGame()
+  game.activeBattle = battle
+  game.mRangestrikeCreature({ attacker, target, rolls })
 }
 
 function setupBattle(terrain: Terrain, attackerTypes: CreatureType[], defenderTypes: CreatureType[]): {

--- a/src/game/models/battle/engine.test.ts
+++ b/src/game/models/battle/engine.test.ts
@@ -9,10 +9,6 @@ import { BattleCreature, performStrike } from "./combatant"
 import { Battle, BattleSide, nextPhase, phaseEnterStrike } from "./engine"
 import { BattlePhase } from "./strike"
 
-// strike/carryover/rangestrike are no longer part of the production API surface (their bodies
-// are inlined at their single call sites in game/battle.ts); tests that need to drive a strike
-// exercise the same mutators production code uses (mAttackCreature etc.) directly on a real
-// TitanGame, the same direct-call pattern game.test.ts uses for mPhaseExitSplit.
 function createGameWithActiveBattle(battle: Battle): TitanGame {
   const game = newGame()
   game.activeBattle = battle

--- a/src/game/models/battle/engine.ts
+++ b/src/game/models/battle/engine.ts
@@ -476,7 +476,7 @@ export class Battle {
 
 // TODO: rolls is never validated against the strike's expected dice count (see
 // getAdjustedStrike/getRangestrike), so a caller can pass the wrong number of dice unnoticed.
-function performAttack(battle: Battle, attacker: BattleCreature, defender: BattleCreature,
+export function performAttack(battle: Battle, attacker: BattleCreature, defender: BattleCreature,
   rolls: number[], toHit: number, rangestrike: boolean): void {
   const totalHits = rolls.filter(roll => roll >= toHit).length
   const hits = Math.min(totalHits, defender.getRemainingHp())
@@ -491,31 +491,6 @@ function performAttack(battle: Battle, attacker: BattleCreature, defender: Battl
     rolls,
     rangestrike
   })
-}
-
-export function strike(battle: Battle, attacker: BattleCreature, defender: BattleCreature,
-  rolls: number[], optionalToHit?: number): void {
-  let toHit = battle.toHitAdjusted(attacker, defender)
-  if (optionalToHit !== undefined) {
-    assert(optionalToHit >= toHit, "Cannot choose a lower to-hit")
-    toHit = optionalToHit
-  }
-  performAttack(battle, attacker, defender, rolls, toHit, false)
-}
-
-export function carryover(battle: Battle, target: BattleCreature): void {
-  // Using an optional chain prevents typescript from learning that battle.activeStrike is present
-  assert(battle.activeStrike !== undefined &&
-    battle.activeStrike.canCarryover, "Cannot carryover")
-  const hits = Math.min(battle.activeStrike.getCarryoverHits(), target.getRemainingHp())
-  battle.activeStrike.carryover({ hits, target: target.hex })
-  wound(target, hits)
-}
-
-export function rangestrike(battle: Battle, attacker: BattleCreature, defender: RangestrikeTarget,
-  rolls: number[]): void {
-  const computedStrike = battle.getRangestrike(attacker, defender)
-  performAttack(battle, attacker, defender.creature, rolls, computedStrike.toHit, true)
 }
 
 export function nextPhase(battle: Battle): void {

--- a/src/game/models/game.test.ts
+++ b/src/game/models/game.test.ts
@@ -2,75 +2,16 @@ import { createPinia, setActivePinia } from "pinia"
 import { beforeEach, describe, expect, it } from "vitest"
 import { Battle } from "@/models/battle"
 import { CreatureType } from "@/models/creature"
+import { createActionContext, createGetters, newGame } from "@/models/game.testUtils"
 import { HexEdge } from "@/models/masterboard"
 import { PlayerId } from "@/models/player"
 import { Random } from "@/models/random"
 import { Stack } from "@/models/stack"
-import { ActionContext, Getters, MasterboardPhase, TitanGame } from "./game"
+import { MasterboardPhase, TitanGame } from "./game"
 
 // doNextPhase deselects the selected stack via the Pinia selection store directly
 // (not through commit), so an active Pinia is needed for it to run at all.
 beforeEach(() => setActivePinia(createPinia()))
-
-const noShuffleRandom: Random = { shuffle: collection => [...collection] }
-
-function newGame(numPlayers = 2): TitanGame {
-  return new TitanGame(numPlayers, noShuffleRandom)
-}
-
-/**
- * Vuex wires TitanGame's getXxx methods together by handing each one the same live
- * `getters` object, so a getter that depends on another (e.g. getActiveStacks needs
- * activePlayerId) reads it off that object instead of recomputing it itself. This
- * mirrors that wiring without a real store: each property recomputes from current game
- * state on every access, which behaves the same as Vuex's reactive getters for the
- * synchronous scenarios below.
- */
-function createGetters(game: TitanGame): Getters {
-  const getters = {} as Getters
-  const lazy = <K extends keyof Getters>(key: K, compute: () => Getters[K]): void => {
-    Object.defineProperty(getters, key, { get: compute, enumerable: true, configurable: true })
-  }
-  lazy("round", () => game.getRound())
-  lazy("firstRound", () => game.getFirstRound())
-  lazy("players", () => game.getPlayers())
-  lazy("playerById", () => game.getPlayerById())
-  lazy("stacksForPlayer", () => game.getStacksForPlayer())
-  lazy("stacksForHex", () => game.getStacksForHex())
-  lazy("activePlayer", () => game.getActivePlayer())
-  lazy("activePlayerId", () => game.getActivePlayerId(getters))
-  lazy("activeStacks", () => game.getActiveStacks(getters))
-  lazy("nextMarker", () => game.getNextMarker(getters) as number)
-  lazy("pathsForHex", () => game.getPathsForHex(getters))
-  lazy("mandatoryMoves", () => game.getMandatoryMoves(getters))
-  lazy("mayProceed", () => game.getMayProceed(getters))
-  lazy("mulliganAvailable", () => game.getMulliganAvailable(getters))
-  lazy("engagedStacks", () => game.getEngagedStacks(getters))
-  return getters
-}
-
-/**
- * Builds an ActionContext whose commit/dispatch forward to TitanGame's own mFoo/doFoo
- * methods - the same mapping src/game/store/game/index.ts sets up for the real Vuex module
- * (mutation "fooBar" -> method "mFooBar", action "fooBar" -> method "doFooBar").
- */
-function createActionContext(
-  game: TitanGame,
-  dispatch: ActionContext["dispatch"] = () => {
-    throw new Error("dispatch was not expected to be called")
-  }
-): ActionContext {
-  const getters = createGetters(game)
-  const commit: ActionContext["commit"] = (name, payload) => {
-    const method = `m${name.charAt(0).toUpperCase()}${name.slice(1)}`
-    ;(game as unknown as Record<string, (payload?: unknown) => void>)[method](payload)
-  }
-  // Actions persist as a side effect; persistence itself is a separate concern (see
-  // persistence.ts) and not under test here, so stub it out rather than exercising
-  // the real localStorage/compression path for every turn/muster action.
-  game.persist = async () => undefined
-  return { state: game, getters, commit, dispatch }
-}
 
 describe("TitanGame", () => {
   it("assigns player colors via the injected Random instead of a fixed order", () => {

--- a/src/game/models/game.testUtils.ts
+++ b/src/game/models/game.testUtils.ts
@@ -1,0 +1,62 @@
+import { ActionContext, Getters, TitanGame } from "./game"
+import { Random } from "./random"
+
+export const noShuffleRandom: Random = { shuffle: collection => [...collection] }
+
+export function newGame(numPlayers = 2): TitanGame {
+  return new TitanGame(numPlayers, noShuffleRandom)
+}
+
+/**
+ * Vuex wires TitanGame's getXxx methods together by handing each one the same live
+ * `getters` object, so a getter that depends on another (e.g. getActiveStacks needs
+ * activePlayerId) reads it off that object instead of recomputing it itself. This
+ * mirrors that wiring without a real store: each property recomputes from current game
+ * state on every access, which behaves the same as Vuex's reactive getters for the
+ * synchronous scenarios below.
+ */
+export function createGetters(game: TitanGame): Getters {
+  const getters = {} as Getters
+  const lazy = <K extends keyof Getters>(key: K, compute: () => Getters[K]): void => {
+    Object.defineProperty(getters, key, { get: compute, enumerable: true, configurable: true })
+  }
+  lazy("round", () => game.getRound())
+  lazy("firstRound", () => game.getFirstRound())
+  lazy("players", () => game.getPlayers())
+  lazy("playerById", () => game.getPlayerById())
+  lazy("stacksForPlayer", () => game.getStacksForPlayer())
+  lazy("stacksForHex", () => game.getStacksForHex())
+  lazy("activePlayer", () => game.getActivePlayer())
+  lazy("activePlayerId", () => game.getActivePlayerId(getters))
+  lazy("activeStacks", () => game.getActiveStacks(getters))
+  lazy("nextMarker", () => game.getNextMarker(getters) as number)
+  lazy("pathsForHex", () => game.getPathsForHex(getters))
+  lazy("mandatoryMoves", () => game.getMandatoryMoves(getters))
+  lazy("mayProceed", () => game.getMayProceed(getters))
+  lazy("mulliganAvailable", () => game.getMulliganAvailable(getters))
+  lazy("engagedStacks", () => game.getEngagedStacks(getters))
+  return getters
+}
+
+/**
+ * Builds an ActionContext whose commit/dispatch forward to TitanGame's own mFoo/doFoo
+ * methods - the same mapping src/game/store/game/index.ts sets up for the real Vuex module
+ * (mutation "fooBar" -> method "mFooBar", action "fooBar" -> method "doFooBar").
+ */
+export function createActionContext(
+  game: TitanGame,
+  dispatch: ActionContext["dispatch"] = () => {
+    throw new Error("dispatch was not expected to be called")
+  }
+): ActionContext {
+  const getters = createGetters(game)
+  const commit: ActionContext["commit"] = (name, payload) => {
+    const method = `m${name.charAt(0).toUpperCase()}${name.slice(1)}`
+    ;(game as unknown as Record<string, (payload?: unknown) => void>)[method](payload)
+  }
+  // Actions persist as a side effect; persistence itself is a separate concern (see
+  // persistence.ts) and not under test here, so stub it out rather than exercising
+  // the real localStorage/compression path for every turn/muster action.
+  game.persist = async () => undefined
+  return { state: game, getters, commit, dispatch }
+}

--- a/src/game/models/game/battle.ts
+++ b/src/game/models/game/battle.ts
@@ -1,6 +1,6 @@
 import { matches } from "lodash-es"
 import { assert } from "@/utils/assert"
-import { Battle, BATTLE_PHASE_TYPES, BattleCreature, BattlePhaseType, BattleSide, RangestrikeTarget, carryover, nextPhase, rangestrike, strike } from "../battle"
+import { Battle, BATTLE_PHASE_TYPES, BattleCreature, BattlePhaseType, BattleSide, RangestrikeTarget, nextPhase, performAttack, wound } from "../battle"
 import masterboard from "../masterboard"
 import { PlayerId } from "../player"
 import { Stack } from "../stack"
@@ -92,18 +92,32 @@ export const gameBattle: GameBattle & ThisType<TitanGame> = {
   mAttackCreature({ attacker, target, rolls, optionalToHit }: AttackPayload): void {
     assert(this.activeBattle?.creatures.some(matches(attacker)) ?? false, "Unexpected attacker")
     assert(this.activeBattle?.creatures.some(matches(target)) ?? false, "Unexpected defender")
-    strike(this.activeBattle!, attacker, target, rolls, optionalToHit)
+    const battle = this.activeBattle!
+    let toHit = battle.toHitAdjusted(attacker, target)
+    if (optionalToHit !== undefined) {
+      assert(optionalToHit >= toHit, "Cannot choose a lower to-hit")
+      toHit = optionalToHit
+    }
+    performAttack(battle, attacker, target, rolls, toHit, false)
   },
 
   mRangestrikeCreature({ attacker, target, rolls }: RangestrikePayload): void {
     assert(this.activeBattle?.creatures.some(matches(attacker)) ?? false, "Unexpected attacker")
     assert(this.activeBattle?.creatures.some(matches(target.creature)) ?? false, "Unexpected defender")
-    rangestrike(this.activeBattle!, attacker, target, rolls)
+    const battle = this.activeBattle!
+    const computedStrike = battle.getRangestrike(attacker, target)
+    performAttack(battle, attacker, target.creature, rolls, computedStrike.toHit, true)
   },
 
   mAssignCarryover(target: BattleCreature): void {
     assert(this.activeBattle?.creatures.some(matches(target)) ?? false, "Unexpected target")
-    carryover(this.activeBattle!, target)
+    const battle = this.activeBattle!
+    // Using an optional chain prevents typescript from learning that battle.activeStrike is present
+    assert(battle.activeStrike !== undefined &&
+      battle.activeStrike.canCarryover, "Cannot carryover")
+    const hits = Math.min(battle.activeStrike.getCarryoverHits(), target.getRemainingHp())
+    battle.activeStrike.carryover({ hits, target: target.hex })
+    wound(target, hits)
   },
 
   mSkipCarryover(): void {


### PR DESCRIPTION
Follow-up correction to #83, which extracted `strike`, `carryover`, and `rangestrike` from `Battle` in [`engine.ts`](https://github.com/aolkin/warlord/blob/main/src/game/models/battle/engine.ts) into standalone exported functions. That extraction counted call sites including test files; per corrected guidance, only production call sites count toward the inline-vs-extract decision.

Each of the three has exactly one production call site, all in [`game/battle.ts`](https://github.com/aolkin/warlord/blob/main/src/game/models/game/battle.ts) (`mAttackCreature`, `mRangestrikeCreature`, `mAssignCarryover`), with small bodies - no size or complexity justification to keep them standalone. Their bodies are now inlined directly into those call sites, and they're removed as exports from `engine.ts` and the `battle.ts` barrel.

`performAttack` is unaffected - it has two genuine internal callers (the inlined `strike` and `rangestrike` logic) and stays a free function, now exported from `engine.ts` so `game/battle.ts` can call it directly.

`engine.test.ts` no longer has direct access to `strike`/`carryover`/`rangestrike`, so its "Battle engagement", "Carryover", and rangestrike-exercising test cases now drive the same behavior through `gameBattle`'s mutators - the same path `game/battle.ts` uses - via thin test-local wrapper functions. Assertions are unchanged.