### PR TITLE
Extract Stack.finalizeSplit into a free function

### DIFF
--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -8,7 +8,7 @@ import { GamePersistence, gamePersistence, GAME_PERSISTENCE_KEY } from "./game/p
 import masterboard, { HexEdge, MasterboardHex } from "./masterboard"
 import { Player, PlayerId } from "./player"
 import { defaultRandom, Random } from "./random"
-import { MusterChoice, Stack } from "./stack"
+import { finalizeSplit, MusterChoice, Stack } from "./stack"
 
 const INITIAL_HEXES: Record<number, number[]> = {
   2: [100, 400],
@@ -215,7 +215,7 @@ export class TitanGame {
       case MasterboardPhase.SPLIT:
         // TODO: check getters.mayProceed before advancing — round-1 split rule (exactly 4 creatures with 1 lord) not yet enforced
         getters.activeStacks.filter(stack => stack.numSplitting() > 0).forEach(stack => {
-          this.stacks.push(stack.finalizeSplit(getters.nextMarker))
+          this.stacks.push(finalizeSplit(stack, getters.nextMarker))
         })
         this.mulliganTaken = false
         break

--- a/src/game/models/stack.test.ts
+++ b/src/game/models/stack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { Stack, MusterBasis } from "./stack"
+import { finalizeSplit, Stack, MusterBasis } from "./stack"
 import { CreatureType } from "./creature"
 import { Terrain } from "./masterboard"
 import { PlayerId } from "./player"
@@ -52,7 +52,7 @@ describe("Stack splitting", () => {
     stack.setPendingSplit(6, true)
     const splitOff = stack.getCreaturesSplit(true)
 
-    const newStack = stack.finalizeSplit(1)
+    const newStack = finalizeSplit(stack, 1)
 
     expect(newStack.owner).toBe(PlayerId.RED)
     expect(newStack.hex).toBe(5)
@@ -68,7 +68,7 @@ describe("Stack splitting", () => {
   it("refuses to finalize an invalid split", () => {
     const stack = new Stack(PlayerId.RED, 5, 0)
     stack.setPendingSplit(0, true) // only 1 marked, never valid
-    expect(() => stack.finalizeSplit(1)).toThrow()
+    expect(() => finalizeSplit(stack, 1)).toThrow()
   })
 })
 

--- a/src/game/models/stack.ts
+++ b/src/game/models/stack.ts
@@ -122,16 +122,16 @@ export class Stack {
     this.split[index] = pending
   }
 
-  finalizeSplit(marker: number): Stack {
-    assert(this.isValidSplit(), "Invalid split")
-    assert(marker >= 0, "Invalid marker")
-    const creatures = this.getCreaturesSplit(true)
-    remove(this.creatures, (creature, index) => this.split[index])
-    this.split.fill(false)
-    return new Stack(this.owner, this.hex, marker, creatures)
-  }
-
   muster(creature: CreatureType): void {
     this.creatures.push(creature)
   }
+}
+
+export function finalizeSplit(stack: Stack, marker: number): Stack {
+  assert(stack.isValidSplit(), "Invalid split")
+  assert(marker >= 0, "Invalid marker")
+  const creatures = stack.getCreaturesSplit(true)
+  remove(stack.creatures, (creature, index) => stack.split[index])
+  stack.split.fill(false)
+  return new Stack(stack.owner, stack.hex, marker, creatures)
 }


### PR DESCRIPTION
Stacks on #84 — review/merge that first.

Converts the mutating `finalizeSplit(marker)` instance method on `Stack` into a free function `finalizeSplit(stack, marker)`, matching the mutator pattern used for [BattleCreature](https://github.com/aolkin/warlord/pull/81) and TitanGame's other phase mutators. `setPendingSplit` and `muster` are left as-is.