### PR TITLE
Extract Stack's setPendingSplit/muster into free functions

### DIFF
--- a/src/game/models/game.test.ts
+++ b/src/game/models/game.test.ts
@@ -6,7 +6,7 @@ import { createActionContext, createGetters, newGame } from "@/models/game.testU
 import { HexEdge } from "@/models/masterboard"
 import { PlayerId } from "@/models/player"
 import { Random } from "@/models/random"
-import { setPendingSplit, Stack } from "@/models/stack"
+import { Stack } from "@/models/stack"
 import { MasterboardPhase, TitanGame } from "./game"
 
 // doNextPhase deselects the selected stack via the Pinia selection store directly
@@ -88,10 +88,10 @@ describe("TitanGame mandatory moves (stack splitting during movement)", () => {
   it("requires splitting apart two stacks sharing a hex until one of them moves away", async () => {
     const game = newGame()
     const original = game.stacks[0]
-    setPendingSplit(original, 0, true) // TITAN
-    setPendingSplit(original, 2, true) // CENTAUR
-    setPendingSplit(original, 4, true) // OGRE
-    setPendingSplit(original, 6, true) // GARGOYLE
+    original.split[0] = true // TITAN
+    original.split[2] = true // CENTAUR
+    original.split[4] = true // OGRE
+    original.split[6] = true // GARGOYLE
     const getters = createGetters(game)
     await game.doNextPhase(createActionContext(game))
     const sibling = game.stacks.at(-1)!
@@ -118,10 +118,10 @@ describe("TitanGame mayProceed for the split phase", () => {
     expect(getters.mayProceed).toBe(false)
 
     const stack = game.stacks[0]
-    setPendingSplit(stack, 0, true)
-    setPendingSplit(stack, 2, true)
-    setPendingSplit(stack, 4, true)
-    setPendingSplit(stack, 6, true)
+    stack.split[0] = true
+    stack.split[2] = true
+    stack.split[4] = true
+    stack.split[6] = true
 
     expect(getters.mayProceed).toBe(true)
   })
@@ -133,10 +133,10 @@ describe("TitanGame turn and phase transitions", () => {
     const original = game.stacks[0]
     // Stale state from a previous turn, cleared on move entry.
     game.mulliganTaken = true
-    setPendingSplit(original, 0, true) // TITAN
-    setPendingSplit(original, 2, true) // CENTAUR
-    setPendingSplit(original, 4, true) // OGRE
-    setPendingSplit(original, 6, true) // GARGOYLE
+    original.split[0] = true // TITAN
+    original.split[2] = true // CENTAUR
+    original.split[4] = true // OGRE
+    original.split[6] = true // GARGOYLE
     const context = createActionContext(game)
 
     await game.doNextPhase(context)
@@ -190,10 +190,10 @@ describe("TitanGame turn and phase transitions", () => {
   it("refuses to leave the move phase with multiple simultaneous engagements", async () => {
     const game = newGame(3) // BLUE @ 100, GREEN @ 300, RED @ 500
     const original = game.stacks[0]
-    setPendingSplit(original, 0, true)
-    setPendingSplit(original, 2, true)
-    setPendingSplit(original, 4, true)
-    setPendingSplit(original, 6, true)
+    original.split[0] = true
+    original.split[2] = true
+    original.split[4] = true
+    original.split[6] = true
     const context = createActionContext(game)
     await game.doNextPhase(context)
     const sibling = game.stacks.at(-1)!

--- a/src/game/models/game.test.ts
+++ b/src/game/models/game.test.ts
@@ -6,7 +6,7 @@ import { createActionContext, createGetters, newGame } from "@/models/game.testU
 import { HexEdge } from "@/models/masterboard"
 import { PlayerId } from "@/models/player"
 import { Random } from "@/models/random"
-import { Stack } from "@/models/stack"
+import { setPendingSplit, Stack } from "@/models/stack"
 import { MasterboardPhase, TitanGame } from "./game"
 
 // doNextPhase deselects the selected stack via the Pinia selection store directly
@@ -88,10 +88,10 @@ describe("TitanGame mandatory moves (stack splitting during movement)", () => {
   it("requires splitting apart two stacks sharing a hex until one of them moves away", async () => {
     const game = newGame()
     const original = game.stacks[0]
-    original.setPendingSplit(0, true) // TITAN
-    original.setPendingSplit(2, true) // CENTAUR
-    original.setPendingSplit(4, true) // OGRE
-    original.setPendingSplit(6, true) // GARGOYLE
+    setPendingSplit(original, 0, true) // TITAN
+    setPendingSplit(original, 2, true) // CENTAUR
+    setPendingSplit(original, 4, true) // OGRE
+    setPendingSplit(original, 6, true) // GARGOYLE
     const getters = createGetters(game)
     await game.doNextPhase(createActionContext(game))
     const sibling = game.stacks.at(-1)!
@@ -118,10 +118,10 @@ describe("TitanGame mayProceed for the split phase", () => {
     expect(getters.mayProceed).toBe(false)
 
     const stack = game.stacks[0]
-    stack.setPendingSplit(0, true)
-    stack.setPendingSplit(2, true)
-    stack.setPendingSplit(4, true)
-    stack.setPendingSplit(6, true)
+    setPendingSplit(stack, 0, true)
+    setPendingSplit(stack, 2, true)
+    setPendingSplit(stack, 4, true)
+    setPendingSplit(stack, 6, true)
 
     expect(getters.mayProceed).toBe(true)
   })
@@ -133,10 +133,10 @@ describe("TitanGame turn and phase transitions", () => {
     const original = game.stacks[0]
     // Stale state from a previous turn, cleared on move entry.
     game.mulliganTaken = true
-    original.setPendingSplit(0, true) // TITAN
-    original.setPendingSplit(2, true) // CENTAUR
-    original.setPendingSplit(4, true) // OGRE
-    original.setPendingSplit(6, true) // GARGOYLE
+    setPendingSplit(original, 0, true) // TITAN
+    setPendingSplit(original, 2, true) // CENTAUR
+    setPendingSplit(original, 4, true) // OGRE
+    setPendingSplit(original, 6, true) // GARGOYLE
     const context = createActionContext(game)
 
     await game.doNextPhase(context)
@@ -190,10 +190,10 @@ describe("TitanGame turn and phase transitions", () => {
   it("refuses to leave the move phase with multiple simultaneous engagements", async () => {
     const game = newGame(3) // BLUE @ 100, GREEN @ 300, RED @ 500
     const original = game.stacks[0]
-    original.setPendingSplit(0, true)
-    original.setPendingSplit(2, true)
-    original.setPendingSplit(4, true)
-    original.setPendingSplit(6, true)
+    setPendingSplit(original, 0, true)
+    setPendingSplit(original, 2, true)
+    setPendingSplit(original, 4, true)
+    setPendingSplit(original, 6, true)
     const context = createActionContext(game)
     await game.doNextPhase(context)
     const sibling = game.stacks.at(-1)!

--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -8,7 +8,7 @@ import { GamePersistence, gamePersistence, GAME_PERSISTENCE_KEY } from "./game/p
 import masterboard, { HexEdge, MasterboardHex } from "./masterboard"
 import { Player, PlayerId } from "./player"
 import { defaultRandom, Random } from "./random"
-import { finalizeSplit, MusterChoice, Stack } from "./stack"
+import { finalizeSplit, muster, MusterChoice, Stack } from "./stack"
 
 const INITIAL_HEXES: Record<number, number[]> = {
   2: [100, 400],
@@ -313,7 +313,7 @@ function startPlayerTurn(stack: Stack): void {
 
 function finalizeMuster(round: number, stack: Stack & { currentMuster: MusterChoice }): CreatureType {
   stack.recruits[round] = stack.currentMuster
-  stack.creatures.push(stack.currentMuster[0])
+  muster(stack, stack.currentMuster[0])
   return stack.currentMuster[0]
 }
 

--- a/src/game/models/game.ts
+++ b/src/game/models/game.ts
@@ -8,7 +8,7 @@ import { GamePersistence, gamePersistence, GAME_PERSISTENCE_KEY } from "./game/p
 import masterboard, { HexEdge, MasterboardHex } from "./masterboard"
 import { Player, PlayerId } from "./player"
 import { defaultRandom, Random } from "./random"
-import { finalizeSplit, muster, MusterChoice, Stack } from "./stack"
+import { finalizeSplit, MusterChoice, Stack } from "./stack"
 
 const INITIAL_HEXES: Record<number, number[]> = {
   2: [100, 400],
@@ -313,7 +313,7 @@ function startPlayerTurn(stack: Stack): void {
 
 function finalizeMuster(round: number, stack: Stack & { currentMuster: MusterChoice }): CreatureType {
   stack.recruits[round] = stack.currentMuster
-  muster(stack, stack.currentMuster[0])
+  stack.creatures.push(stack.currentMuster[0])
   return stack.currentMuster[0]
 }
 

--- a/src/game/models/stack.test.ts
+++ b/src/game/models/stack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { finalizeSplit, muster, Stack, MusterBasis, setPendingSplit } from "./stack"
+import { finalizeSplit, Stack, MusterBasis } from "./stack"
 import { CreatureType } from "./creature"
 import { Terrain } from "./masterboard"
 import { PlayerId } from "./player"
@@ -10,16 +10,16 @@ describe("Stack splitting", () => {
     // Default 8: [TITAN, ANGEL, CENTAUR, CENTAUR, OGRE, OGRE, GARGOYLE, GARGOYLE]
     expect(stack.isValidSplit(true)).toBe(false) // nothing marked yet
 
-    setPendingSplit(stack, 0, true) // TITAN
-    setPendingSplit(stack, 2, true) // CENTAUR
-    setPendingSplit(stack, 4, true) // OGRE
+    stack.split[0] = true // TITAN
+    stack.split[2] = true // CENTAUR
+    stack.split[4] = true // OGRE
     expect(stack.isValidSplit(true)).toBe(false) // only 3 marked
 
-    setPendingSplit(stack, 1, true) // ANGEL - now 4 marked but 2 lords (TITAN + ANGEL)
+    stack.split[1] = true // ANGEL - now 4 marked but 2 lords (TITAN + ANGEL)
     expect(stack.isValidSplit(true)).toBe(false)
 
-    setPendingSplit(stack, 1, false)
-    setPendingSplit(stack, 6, true) // GARGOYLE - back to 4 marked, 1 lord (TITAN)
+    stack.split[1] = false
+    stack.split[6] = true // GARGOYLE - back to 4 marked, 1 lord (TITAN)
     expect(stack.isValidSplit(true)).toBe(true)
   })
 
@@ -27,29 +27,29 @@ describe("Stack splitting", () => {
     const stack = new Stack(PlayerId.RED, 5, 0)
     expect(stack.isValidSplit()).toBe(true) // no pending split is always valid outside round 1
 
-    setPendingSplit(stack, 0, true)
+    stack.split[0] = true
     expect(stack.isValidSplit()).toBe(false) // splitting exactly 1 creature is never valid
 
-    setPendingSplit(stack, 1, true)
+    stack.split[1] = true
     expect(stack.isValidSplit()).toBe(true) // 2 splitting, 6 remaining
 
     // Splitting off 6 of 8 would leave only 2 behind, which is still valid...
-    for (let i = 2; i < 6; i++) setPendingSplit(stack, i, true)
+    for (let i = 2; i < 6; i++) stack.split[i] = true
     expect(stack.numSplitting()).toBe(6)
     expect(stack.isValidSplit()).toBe(true)
 
     // ...but leaving fewer than 2 behind is not.
-    setPendingSplit(stack, 6, true)
+    stack.split[6] = true
     expect(stack.numSplitting()).toBe(7)
     expect(stack.isValidSplit()).toBe(false)
   })
 
   it("finalizes a split into a new stack sharing the same hex but a new marker", () => {
     const stack = new Stack(PlayerId.RED, 5, 0)
-    setPendingSplit(stack, 0, true)
-    setPendingSplit(stack, 2, true)
-    setPendingSplit(stack, 4, true)
-    setPendingSplit(stack, 6, true)
+    stack.split[0] = true
+    stack.split[2] = true
+    stack.split[4] = true
+    stack.split[6] = true
     const splitOff = stack.getCreaturesSplit(true)
 
     const newStack = finalizeSplit(stack, 1)
@@ -67,7 +67,7 @@ describe("Stack splitting", () => {
 
   it("refuses to finalize an invalid split", () => {
     const stack = new Stack(PlayerId.RED, 5, 0)
-    setPendingSplit(stack, 0, true) // only 1 marked, never valid
+    stack.split[0] = true // only 1 marked, never valid
     expect(() => finalizeSplit(stack, 1)).toThrow()
   })
 })
@@ -83,12 +83,8 @@ describe("Stack mustering eligibility", () => {
 
     expect(stack.canMuster()).toBe(expected)
   })
-
-  it("adds a mustered creature to the stack", () => {
-    const stack = new Stack(PlayerId.RED, 5, 0, [CreatureType.CENTAUR])
-    muster(stack, CreatureType.LION)
-    expect(stack.creatures).toEqual([CreatureType.CENTAUR, CreatureType.LION])
-  })
+  // Adding a mustered creature to the stack is exercised end-to-end by
+  // "applies the pending muster to the stack and pool when the muster phase ends" in game.test.ts.
 })
 
 describe("Stack musterable (recruit-tier constraints)", () => {

--- a/src/game/models/stack.test.ts
+++ b/src/game/models/stack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { finalizeSplit, Stack, MusterBasis } from "./stack"
+import { finalizeSplit, muster, Stack, MusterBasis, setPendingSplit } from "./stack"
 import { CreatureType } from "./creature"
 import { Terrain } from "./masterboard"
 import { PlayerId } from "./player"
@@ -10,16 +10,16 @@ describe("Stack splitting", () => {
     // Default 8: [TITAN, ANGEL, CENTAUR, CENTAUR, OGRE, OGRE, GARGOYLE, GARGOYLE]
     expect(stack.isValidSplit(true)).toBe(false) // nothing marked yet
 
-    stack.setPendingSplit(0, true) // TITAN
-    stack.setPendingSplit(2, true) // CENTAUR
-    stack.setPendingSplit(4, true) // OGRE
+    setPendingSplit(stack, 0, true) // TITAN
+    setPendingSplit(stack, 2, true) // CENTAUR
+    setPendingSplit(stack, 4, true) // OGRE
     expect(stack.isValidSplit(true)).toBe(false) // only 3 marked
 
-    stack.setPendingSplit(1, true) // ANGEL - now 4 marked but 2 lords (TITAN + ANGEL)
+    setPendingSplit(stack, 1, true) // ANGEL - now 4 marked but 2 lords (TITAN + ANGEL)
     expect(stack.isValidSplit(true)).toBe(false)
 
-    stack.setPendingSplit(1, false)
-    stack.setPendingSplit(6, true) // GARGOYLE - back to 4 marked, 1 lord (TITAN)
+    setPendingSplit(stack, 1, false)
+    setPendingSplit(stack, 6, true) // GARGOYLE - back to 4 marked, 1 lord (TITAN)
     expect(stack.isValidSplit(true)).toBe(true)
   })
 
@@ -27,29 +27,29 @@ describe("Stack splitting", () => {
     const stack = new Stack(PlayerId.RED, 5, 0)
     expect(stack.isValidSplit()).toBe(true) // no pending split is always valid outside round 1
 
-    stack.setPendingSplit(0, true)
+    setPendingSplit(stack, 0, true)
     expect(stack.isValidSplit()).toBe(false) // splitting exactly 1 creature is never valid
 
-    stack.setPendingSplit(1, true)
+    setPendingSplit(stack, 1, true)
     expect(stack.isValidSplit()).toBe(true) // 2 splitting, 6 remaining
 
     // Splitting off 6 of 8 would leave only 2 behind, which is still valid...
-    for (let i = 2; i < 6; i++) stack.setPendingSplit(i, true)
+    for (let i = 2; i < 6; i++) setPendingSplit(stack, i, true)
     expect(stack.numSplitting()).toBe(6)
     expect(stack.isValidSplit()).toBe(true)
 
     // ...but leaving fewer than 2 behind is not.
-    stack.setPendingSplit(6, true)
+    setPendingSplit(stack, 6, true)
     expect(stack.numSplitting()).toBe(7)
     expect(stack.isValidSplit()).toBe(false)
   })
 
   it("finalizes a split into a new stack sharing the same hex but a new marker", () => {
     const stack = new Stack(PlayerId.RED, 5, 0)
-    stack.setPendingSplit(0, true)
-    stack.setPendingSplit(2, true)
-    stack.setPendingSplit(4, true)
-    stack.setPendingSplit(6, true)
+    setPendingSplit(stack, 0, true)
+    setPendingSplit(stack, 2, true)
+    setPendingSplit(stack, 4, true)
+    setPendingSplit(stack, 6, true)
     const splitOff = stack.getCreaturesSplit(true)
 
     const newStack = finalizeSplit(stack, 1)
@@ -67,7 +67,7 @@ describe("Stack splitting", () => {
 
   it("refuses to finalize an invalid split", () => {
     const stack = new Stack(PlayerId.RED, 5, 0)
-    stack.setPendingSplit(0, true) // only 1 marked, never valid
+    setPendingSplit(stack, 0, true) // only 1 marked, never valid
     expect(() => finalizeSplit(stack, 1)).toThrow()
   })
 })
@@ -86,7 +86,7 @@ describe("Stack mustering eligibility", () => {
 
   it("adds a mustered creature to the stack", () => {
     const stack = new Stack(PlayerId.RED, 5, 0, [CreatureType.CENTAUR])
-    stack.muster(CreatureType.LION)
+    muster(stack, CreatureType.LION)
     expect(stack.creatures).toEqual([CreatureType.CENTAUR, CreatureType.LION])
   })
 })

--- a/src/game/models/stack.ts
+++ b/src/game/models/stack.ts
@@ -117,12 +117,8 @@ export class Stack {
   }
 }
 
-export function setPendingSplit(stack: Stack, index: number, pending: boolean): void {
-  stack.split[index] = pending
-}
-
-export function muster(stack: Stack, creature: CreatureType): void {
-  stack.creatures.push(creature)
+export function togglePendingSplit(stack: Stack, index: number): void {
+  stack.split[index] = !stack.split[index]
 }
 
 export function finalizeSplit(stack: Stack, marker: number): Stack {

--- a/src/game/models/stack.ts
+++ b/src/game/models/stack.ts
@@ -115,16 +115,14 @@ export class Stack {
     }
     return possibilities
   }
+}
 
-  // MUTATING METHODS - todo, change this
+export function setPendingSplit(stack: Stack, index: number, pending: boolean): void {
+  stack.split[index] = pending
+}
 
-  setPendingSplit(index: number, pending: boolean): void {
-    this.split[index] = pending
-  }
-
-  muster(creature: CreatureType): void {
-    this.creatures.push(creature)
-  }
+export function muster(stack: Stack, creature: CreatureType): void {
+  stack.creatures.push(creature)
 }
 
 export function finalizeSplit(stack: Stack, marker: number): Stack {

--- a/src/ui/components/ui/game/StackPanel.vue
+++ b/src/ui/components/ui/game/StackPanel.vue
@@ -116,7 +116,7 @@ import { CREATURE_DATA, CreatureType } from "@/models/creature"
 import { MasterboardPhase } from "@/models/game"
 import masterboard, { Terrain } from "@/models/masterboard"
 import { Player } from "@/models/player"
-import { MusterChoice, MusterPossibility, Stack } from "@/models/stack"
+import { MusterChoice, MusterPossibility, setPendingSplit, Stack } from "@/models/stack"
 import { useTypedStore } from "~/plugins/vuex"
 import { useSelectionStore } from "~/stores/ui/selection"
 import { mod } from "~/utils/math"
@@ -185,7 +185,8 @@ const musteringCaption = computed(() => {
 
 function toggleSplit(index: number): void {
   if (activePhase.value === MasterboardPhase.SPLIT && (selectionStore.focusedStack?.creatures.length ?? 0) > 2) {
-    selectionStore.focusedStack!.split[index] = !selectionStore.focusedStack!.split[index]
+    const stack = selectionStore.focusedStack!
+    setPendingSplit(stack, index, !stack.split[index])
   }
 }
 

--- a/src/ui/components/ui/game/StackPanel.vue
+++ b/src/ui/components/ui/game/StackPanel.vue
@@ -116,7 +116,7 @@ import { CREATURE_DATA, CreatureType } from "@/models/creature"
 import { MasterboardPhase } from "@/models/game"
 import masterboard, { Terrain } from "@/models/masterboard"
 import { Player } from "@/models/player"
-import { MusterChoice, MusterPossibility, setPendingSplit, Stack } from "@/models/stack"
+import { MusterChoice, MusterPossibility, Stack, togglePendingSplit } from "@/models/stack"
 import { useTypedStore } from "~/plugins/vuex"
 import { useSelectionStore } from "~/stores/ui/selection"
 import { mod } from "~/utils/math"
@@ -186,7 +186,7 @@ const musteringCaption = computed(() => {
 function toggleSplit(index: number): void {
   if (activePhase.value === MasterboardPhase.SPLIT && (selectionStore.focusedStack?.creatures.length ?? 0) > 2) {
     const stack = selectionStore.focusedStack!
-    setPendingSplit(stack, index, !stack.split[index])
+    togglePendingSplit(stack, index)
   }
 }
 


### PR DESCRIPTION
`StackPanel.vue`'s [split toggle](https://github.com/aolkin/warlord/blob/main/src/ui/components/ui/game/StackPanel.vue) and `TitanGame`'s `finalizeMuster` mutated `stack.split[index]` and `stack.creatures` directly rather than going through `Stack`'s own `setPendingSplit`/`muster` methods. This converts those two methods into free functions taking `stack: Stack` explicitly, alongside `finalizeSplit`, and updates both call sites to use them instead of mutating fields inline.

No behavior change.