### PR TITLE
Inline ActiveStrike.carryover/skipCarryover into their single call sites

### DIFF
--- a/src/game/models/battle/engine.test.ts
+++ b/src/game/models/battle/engine.test.ts
@@ -275,7 +275,7 @@ describe("Carryover", () => {
     game.mAttackCreature({ attacker: lion, target: centaur1, rolls: [6, 6, 6, 6, 6] })
     expect(battle.activeStrike?.canCarryover).toBe(true)
 
-    battle.activeStrike?.skipCarryover()
+    game.mSkipCarryover()
 
     expect(battle.activeStrike?.canCarryover).toBe(false)
     expect(battle.carryoverTargets()).toBeUndefined()

--- a/src/game/models/battle/strike.ts
+++ b/src/game/models/battle/strike.ts
@@ -96,13 +96,4 @@ export class ActiveStrike {
   get canCarryover(): boolean {
     return !this.rangestrike && !this.carryoverSkipped && this.getCarryoverHits() > 0
   }
-
-  carryover(strike: ActiveStrikeHit): void {
-    this.targets.push(strike.target)
-    this.targetHits.push(strike.hits)
-  }
-
-  skipCarryover(): void {
-    this.carryoverSkipped = true
-  }
 }

--- a/src/game/models/game/battle.ts
+++ b/src/game/models/game/battle.ts
@@ -116,12 +116,16 @@ export const gameBattle: GameBattle & ThisType<TitanGame> = {
     assert(battle.activeStrike !== undefined &&
       battle.activeStrike.canCarryover, "Cannot carryover")
     const hits = Math.min(battle.activeStrike.getCarryoverHits(), target.getRemainingHp())
-    battle.activeStrike.carryover({ hits, target: target.hex })
+    battle.activeStrike.targets.push(target.hex)
+    battle.activeStrike.targetHits.push(hits)
     wound(target, hits)
   },
 
   mSkipCarryover(): void {
-    this.activeBattle?.activeStrike?.skipCarryover()
+    const activeStrike = this.activeBattle?.activeStrike
+    if (activeStrike !== undefined) {
+      activeStrike.carryoverSkipped = true
+    }
   },
 
   async doInitiateBattle({ commit, getters }: ActionContext, attacking: Stack): Promise<void> {


### PR DESCRIPTION
Follow-up in the same vein as [#86](https://github.com/aolkin/warlord/pull/86): `ActiveStrike.carryover()` and `ActiveStrike.skipCarryover()` in [`strike.ts`](https://github.com/aolkin/warlord/blob/main/src/game/models/battle/strike.ts) each had exactly one production call site, both in [`game/battle.ts`](https://github.com/aolkin/warlord/blob/main/src/game/models/game/battle.ts) (`mAssignCarryover`, `mSkipCarryover`), with bodies too small to justify staying separate. Both are now inlined directly into those mutators and removed from `ActiveStrike`.

`engine.test.ts`'s "stops carryover once skipCarryover is called" test called `skipCarryover()` directly on `activeStrike`; since that method no longer exists, it now drives the same behavior through `game.mSkipCarryover()`, matching how the adjacent carryover test already goes through the game mutator layer.

No behavior change.